### PR TITLE
Remove references to SC

### DIFF
--- a/lib/i18n.coffee
+++ b/lib/i18n.coffee
@@ -69,9 +69,6 @@ I18n = {
       result
 }
 
-# DEPRECATE: The use of SC.I18n is being deprecated.
-SC.I18n = I18n
-
 Em.I18n = I18n
 Ember.I18n = I18n
 

--- a/spec/javascripts/i18nSpec.coffee
+++ b/spec/javascripts/i18nSpec.coffee
@@ -47,7 +47,7 @@ describe 'Em.I18n', ->
       expect(Em.I18n.t('foo.bar')).toEqual('A Foobar')
 
     it 'interpolates', ->
-      expect(SC.I18n.t('foo.bar.named', { name: 'Sue' })).toEqual('A Foobar named Sue')
+      expect(Em.I18n.t('foo.bar.named', { name: 'Sue' })).toEqual('A Foobar named Sue')
 
     it 'uses the "zero" form when the language calls for it', ->
       expect(Em.I18n.t('foos', { count: 0 })).toEqual('No Foos')


### PR DESCRIPTION
Reason: ember-latest no longer provides the SC-Namespace
