### PR TITLE
Use context when binding with the "t" helper

### DIFF
--- a/lib/i18n.coffee
+++ b/lib/i18n.coffee
@@ -96,7 +96,7 @@ Handlebars.registerHelper 't', (key, options) ->
       # Get the current values for any bound properties:
       propertyName = isBindingMatch[1]
       bindPath = attrs[property]
-      currentValue = getPath bindPath
+      currentValue = getPath context, bindPath
       attrs[propertyName] = currentValue
 
       # Set up an observer for changes:


### PR DESCRIPTION
Changed the "getPath" call when getting the current value of a bound attribute in the "t" Handlebars helper so the object's context is used.
