### PR TITLE
Changing ember_assert to Ember.assert

### DIFF
--- a/lib/i18n.coffee
+++ b/lib/i18n.coffee
@@ -8,8 +8,10 @@ pluralForm = CLDR.pluralForm if CLDR?
 
 Ember.Logger.warn "CLDR.pluralForm not found. Em.I18n will not support count-based inflection." unless pluralForm?
 
+assert = if Ember.assert? then Ember.assert else ember_assert
+
 findTemplate = (key, setOnMissing) ->
-  Ember.assert("You must provide a translation key string, not %@".fmt(key), typeof key is 'string')
+  assert("You must provide a translation key string, not %@".fmt(key), typeof key is 'string')
   result = I18n.translations[key]
   if setOnMissing
     result ?= I18n.translations[key] = I18n.compile "Missing translation: " + key


### PR DESCRIPTION
Deprecated in Ember 0.9.8.1 - updating to stop getting a blizzard of deprecation warnings.

This might break for older versions of Ember, though, so no rush.
