### PR TITLE
Uses Ember.assert if present, falls back to ember_assert

### DIFF
--- a/lib/i18n.coffee
+++ b/lib/i18n.coffee
@@ -18,8 +18,11 @@ lookupKey = (key, hash) ->
     result = lookupKey(remainingKeys, hash) if hash
   result
 
+# If we're on pre-1.0 versions of Ember, we need ember_assert; otherwise use Ember.assert to avoid deprecation warnings.
+assert = if Ember.assert? then Ember.assert else ember_assert
+
 findTemplate = (key, setOnMissing) ->
-  ember_assert("You must provide a translation key string, not %@".fmt(key), typeof key is 'string')
+  assert("You must provide a translation key string, not %@".fmt(key), typeof key is 'string')
   result = lookupKey(key, I18n.translations)
   if setOnMissing
     result ?= I18n.translations[key] = I18n.compile "Missing translation: " + key


### PR DESCRIPTION
ember_assert was deprecated between 0.9.8.1 and 1.0pre, and in later versions of Ember using it produces a deprecation warning. So we use Ember.assert if it's there, and fall back to ember_assert for people using older versions of Ember.

This replaces PR #15.
