### PR TITLE
Plugin breaks if jQuery.noConflict is set

### DIFF
--- a/lib/i18n.coffee
+++ b/lib/i18n.coffee
@@ -28,7 +28,7 @@ findTemplate = (key, setOnMissing) ->
   result = lookupKey(key, I18n.translations)
   if setOnMissing
     result ?= I18n.translations[key] = I18n.compile "Missing translation: " + key
-  if result? and not $.isFunction(result)
+  if result? and not jQuery.isFunction(result)
     result = I18n.translations[key] = I18n.compile result
   result
 


### PR DESCRIPTION
There's a $.isFunction in the code that breaks if jQuery's noConflict mode is set.

I replaced it with jQuery.isFunction.

Unfortunately, I could not get the specs to work (problems with jasmin-webkit-specrunner and bower).
