### PR TITLE
Tests pass with ember 1.0.0-pre4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Internationalization for Ember
 
+## Dependencies
+
+ember-i18n v2.0.0 requires ember 1.0.0-pre4 or higher.  For earlier versions of
+ember, please use [ember-i18n
+v1.3.2](https://github.com/jamesarosen/ember-i18n/tree/v1.3.2).
+
 ### Requirements
 
 Set `Em.I18n.translations` to an object containing your translation

--- a/component.json
+++ b/component.json
@@ -1,13 +1,12 @@
 {
   "name": "ember-i18n",
-  "version": "1.3.2",
+  "version": "2.0.0-pre.1",
   "description": "I18n support for Ember.js",
   "main": [ "lib/i18n.js" ],
   "dependencies": {
     "cldr": "~1.0",
-    "jquery": "~1.7.2",
     "handlebars": "~1.0",
-    "ember": "~0.9.7"
+    "ember": "~1.0.0-pre"
   },
   "scripts": {
     "test": "rake"

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -46,6 +46,7 @@
   };
 
   I18n = {
+    uuid: 0,
     compile: Handlebars.compile,
 
     translations: {},
@@ -99,7 +100,7 @@
     view = data.view;
     tagName = attrs.tagName || 'span';
     delete attrs.tagName;
-    elementID = "i18n-" + (jQuery.uuid++);
+    elementID = "i18n-" + (++I18n.uuid);
 
     Em.keys(attrs).forEach(function(property) {
       var bindPath, currentValue, invoker, isBindingMatch, normalized, normalizedPath, observer, propertyName, root, _ref;

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -13,8 +13,8 @@
 src_files:
   - components/ember/lib/headless-ember.js
   - components/jquery/jquery.js
-  - components/handlebars.js/handlebars-1*.js
-  - components/ember/lib/ember*.js
+  - components/handlebars/handlebars.js
+  - components/ember/**/ember.js
   - components/cldr/plurals.js
   - lib/i18n.js
 


### PR DESCRIPTION
Also, explicitly testing support for translations that use helpers.  Note
that these helpers must be registered with `Handlebars`, not
`Ember.Handlebars`. This means bound helpers aren't supported.
