### PR TITLE
Add TranslateableProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ yields
 
 if `user.getPath('followers.count)` returns `2`.
 
+#### Translate properties on any object:
+
+The `Em.I18n.TranslateableProperties` mixin automatically translates
+any property ending in `"Translation"`:
+
+    user = Em.Object.extend(Em.I18n.TranslateableProperties, {
+      labelTranslation: 'user.label'
+    });
+
+    user.get('label'); "User: "
+
 #### Translate attributes in a view:
 
 Add the mixin `Em.Button.reopen.call(Em.Button, Em.I18n.TranslateableAttributes)` and use like this:

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -1,7 +1,8 @@
 (function(window) {
-  var I18n, assert, findTemplate, get, isBinding, lookupKey, pluralForm;
+  var I18n, assert, findTemplate, get, set, isBinding, lookupKey, pluralForm;
 
   get = Ember.Handlebars.get || Ember.Handlebars.getPath || Ember.getPath;
+  set = Ember.set;
 
   if (typeof CLDR !== "undefined" && CLDR !== null) pluralForm = CLDR.pluralForm;
 
@@ -74,6 +75,16 @@
       template = I18n.template(key, context.count);
       return template(context);
     },
+
+    TranslateableProperties: Em.Mixin.create({
+      init: function() {
+        var result = this._super.apply(this, arguments);
+        eachTranslatedAttribute(this, function(attribute, translation) {
+          set(this, attribute, translation);
+        });
+        return result;
+      }
+    }),
 
     TranslateableAttributes: Em.Mixin.create({
       didInsertElement: function() {

--- a/spec/i18nSpec.js
+++ b/spec/i18nSpec.js
@@ -223,17 +223,26 @@
       });
     });
 
-    describe('TranslatableAttributes', function() {
+    describe('TranslateableProperties', function() {
+
+      it('translates ___Translation attributes on the object', function() {
+        var subject = Em.Object.extend(Em.I18n.TranslateableProperties).create({
+          titleTranslation: 'foo.bar'
+        });
+        expect(subject.get('title')).to.equal('A Foobar');
+      });
+
+    });
+
+    describe('TranslateableAttributes', function() {
       it('exists', function() {
         expect(Em.I18n.TranslateableAttributes).to.not.equal(undefined);
       });
 
-      it('translates ___Translation attributes', function() {
+      it('translates ___Translation attributes on the DOM element', function() {
         Em.View.reopen(Em.I18n.TranslateableAttributes);
         render('{{view titleTranslation="foo.bar"}}');
-        Em.run(function() {
-          expect(view.$().children().first().attr('title')).to.equal("A Foobar");
-        });
+        expect(view.$().children().first().attr('title')).to.equal("A Foobar");
       });
     });
   });


### PR DESCRIPTION
The `TranslateableProperties` mixin acts like the `TranslateableAttributes` mixin but sets the translated values on the object itself instead of as DOM attributes.

I considered making the translations computed properties that use the object itself as the context for the translation, but I couldn't think of a way (other than making them all `volatile`) of expiring the computed translations. I'm open to the idea, but not yet sold.
