### PR TITLE
Fix ember version range syntax.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "cldr": "~1.0",
     "jquery": "~1.7",
     "handlebars": "~1.0",
-    "ember": ">0.9.7, <1.1"
+    "ember": ">0.9.7 <1.1"
   },
   "scripts": {
     "test": "rake"


### PR DESCRIPTION
Looks like semver doesn't like commas:

``` js
var Range = require('semver').Range;
new Range(">0.9.7, <1.1"); // throws "Invalid comparator: ,"
```
