### PR TITLE
Added `Ember.I18n.on` + missing translations now trigger `missing` events

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -37,6 +37,7 @@
         result = I18n.translations[key] = function() { return "Missing translation: " + key; };
         result._isMissing = true;
         warn("Missing translation: " + key);
+        I18n[(typeof I18n.trigger === 'function' ? 'trigger' : 'fire')]('missing', key); //Support 0.9 style .fire
       }
     }
 
@@ -64,7 +65,7 @@
     }
   }
 
-  I18n = {
+  I18n = Ember.Evented.apply({
     compile: Handlebars.compile,
 
     translations: {},
@@ -107,7 +108,7 @@
         return result;
       }
     })
-  };
+  });
 
   Ember.I18n = I18n;
 

--- a/spec/i18nSpec.js
+++ b/spec/i18nSpec.js
@@ -99,6 +99,25 @@
         expect(Em.I18n.t('nothing.here')).to.equal('Missing translation: nothing.here');
       });
 
+      describe('missing event', function() {
+        var observer;
+        
+        afterEach(function() {
+            Ember.I18n.off('missing', observer);
+        });
+
+        it('triggers missing events when translations are missing', function() {
+          var didCall = false;
+          observer = function(key) {
+            expect(key).to.equal('nothing.here');
+            didCall = true;
+          };
+          Ember.I18n.on('missing', observer);
+          Em.I18n.t('nothing.here');
+          expect(didCall).to.equal(true);
+        });
+      });
+
       describe('using nested objects', function() {
         it('works with a simple case', function() {
           expect(Em.I18n.t('baz.qux')).to.equal('A qux appears');


### PR DESCRIPTION
When running automated tests it would be awesome to be able to fail tests if a translation is missing. With this addition we will be able to do this:

``` javascript
if (Ember.testing) {
  Ember.I18n.on('missing', function(key) {
    throw new Error('Missing translation: '+key);
  });
}
```
