### PR TITLE
Add className attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ yields
 
     <h2 id="i18n-123">Edit User</h2>
 
+#### Define a `class` attribute by specifying a `className`:
+
+    {{t user.edit.title className="edit"}}
+
+yields
+
+    <span class="edit" id="i18n-123">Edit User</span>
+
 #### Set interpoloated values directly:
 
     <h2>{{t user.followers.title count="2"}}</h2>

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -124,13 +124,15 @@
   })();
 
   Handlebars.registerHelper('t', function(key, options) {
-    var attrs, context, data, elementID, result, tagName, view;
+    var attrs, context, data, elementID, result, tagName, classAttr, view;
     context = this;
     attrs = options.hash;
     data = options.data;
     view = data.view;
     tagName = attrs.tagName || 'span';
+    classAttr = attrs.className ? 'class="' + attrs.className + '"' : '';
     delete attrs.tagName;
+    delete attrs.className;
     elementID = uniqueElementId();
 
     Em.keys(attrs).forEach(function(property) {
@@ -166,7 +168,7 @@
       }
     });
 
-    result = '<%@ id="%@">%@</%@>'.fmt(tagName, elementID, I18n.t(key, attrs), tagName);
+    result = '<%@ %@ id="%@">%@</%@>'.fmt(tagName, classAttr, elementID, I18n.t(key, attrs), tagName);
     return new Handlebars.SafeString(result);
   });
 

--- a/spec/i18nSpec.js
+++ b/spec/i18nSpec.js
@@ -190,6 +190,14 @@
         });
       });
 
+      it('obeys a custom class name', function() {
+        render('{{t foo.bar className="klass"}}');
+
+        Em.run(function() {
+          expect(view.$('.klass').html()).to.equal('A Foobar');
+        });
+      });
+
       it('handles interpolations from contextual keywords', function() {
         render('{{t foo.bar.named nameBinding="view.favouriteBeer" }}', {
           favouriteBeer: 'IPA'


### PR DESCRIPTION
While it was nice to be able to change the `tagName`, it seemed
incomplete without the ability to add a `class` attribute to the tag.

This commit includes the functionality, the test, and the documentation.
