### PR TITLE
Adds a shorthand for {{translateAttr}} named {{ta}}

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -171,7 +171,7 @@
     return new Handlebars.SafeString(result);
   });
 
-  Handlebars.registerHelper('translateAttr', function(options) {
+  var attrHelperFunction = function(options) {
     var attrs, result;
     attrs = options.hash;
     result = [];
@@ -183,6 +183,9 @@
     });
 
     return new Handlebars.SafeString(result.join(' '));
-  });
+  };
+    
+  Handlebars.registerHelper('translateAttr', attrHelperFunction);
+  Handlebars.registerHelper('ta', attrHelperFunction);
 
 }).call(undefined, this);

--- a/spec/i18nSpec.js
+++ b/spec/i18nSpec.js
@@ -257,6 +257,26 @@
       });
     });
 
+    describe('{{ta}}', function() {
+      it('outputs translated attribute strings', function() {
+        render('<a {{ta title="foo.bar" data-disable-with="foo.save.disabled"}}></a>');
+        Em.run(function() {
+          expect(view.$('a').attr('title')).to.equal('A Foobar');
+          expect(view.$('a').attr('data-disable-with')).to.equal('Saving Foo...');
+        });
+      });
+    });
+
+    describe('{{ta}} == {{translateAttr}}', function() {
+      it('check that {{ta}} and {{translateAttr}} outputs the same', function() {
+        render('<a {{ta title="foo.bar" data-disable-with="foo.save.disabled"}}></a><span {{translateAttr title="foo.bar" data-disable-with="foo.save.disabled"}}></span>');
+        Em.run(function() {
+          expect(view.$('a').attr('title')).to.equal(view.$('span').attr('title'));
+          expect(view.$('a').attr('data-disable-with')).to.equal(view.$('span').attr('data-disable-with'));
+        });
+      });
+    });
+
     describe('TranslateableProperties', function() {
 
       it('translates ___Translation attributes on the object', function() {


### PR DESCRIPTION
I've been using this shorthand a lot in my recent project and everyone on the team feels that if we use {{t}} for regular translations then {{ta}} for attributes is a no brainer. The pull requests adds support for {{ta}} but also keeps {{translateAttr} and adds tests for {{ta}} itself and a comparison-test so that they don't stray apart in the future.
