### PR TITLE
Use the afterRender queue if available

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -1,6 +1,6 @@
 (function(window) {
   var I18n, assert, findTemplate, get, set, isBinding, lookupKey, pluralForm,
-      keyExists;
+      keyExists, runAfterRender;
 
   get = Ember.Handlebars.get || Ember.Handlebars.getPath || Ember.getPath;
   set = Ember.set;
@@ -52,6 +52,19 @@
     var translation = lookupKey(key, I18n.translations);
     return translation != null && !translation._isMissing;
   };
+
+  runAfterRender = (function() {
+    if (Em.run.queues.indexOf('afterRender') === -1) {
+      // Ember 0.9 doesn't have an afterRender queue.
+      return function runAfterRender(callback) {
+        return Em.run.once(callback);
+      };
+    }
+
+    return function runAfterRender(callback) {
+      return Em.run.scheduleOnce('afterRender', callback);
+    };
+  }());
 
   function eachTranslatedAttribute(object, fn) {
     var isTranslatedAttribute = /(.+)Translation$/,
@@ -164,7 +177,7 @@
         };
 
         invoker = function() {
-          return Em.run.once(observer);
+          return runAfterRender(observer);
         };
 
         return Em.addObserver(root, normalizedPath, invoker);
@@ -188,7 +201,7 @@
 
     return new Handlebars.SafeString(result.join(' '));
   };
-    
+
   Handlebars.registerHelper('translateAttr', attrHelperFunction);
   Handlebars.registerHelper('ta', attrHelperFunction);
 


### PR DESCRIPTION
@shajith @rlivsey
Ember 0.9 doesn't have an `afterRender` queue, but Ember 1.0 does. If it's present, use it for invoking updates in the `t` helper.
