### PR TITLE
Update README to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ also need to include the
 [CLDR.js pluralization library](https://github.com/jamesarosen/CLDR.js)
 and set `CLDR.defaultLanguage` to the current locale code (e.g. "de").
 
+> Include the full `handlebars.js` library, it's needed to compile the templates (e.g. not handlebars.runtime.js).
+
 ### Examples
 
 Given


### PR DESCRIPTION
Update README.md with a small note in the 'Requirements' section, to avoid confusion and a common error. 

Simply referencing the lightweight runtime version of handlebars `(handlebars.runtime.js)` in your project is not enough, the runtime version doesn't contain the compile function required to compile the templates. The full `handlebars.js` library should be included. 

The fact that you should use the full library isn't noted anywhere. I'm sure this will help people installing the plugin avoid the common error. 

Related to #45 and #63.
