### PR TITLE
Allow for class to be passed on the t helper

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -167,8 +167,15 @@
     data = options.data;
     view = data.view;
     tagName = attrs.tagName || 'span';
+    classNames = attrs.class || '';
+
+    delete attrs.class;
     delete attrs.tagName;
     elementID = uniqueElementId();
+    if(classNames) {
+      classNames = 'class="'+classNames+'"';
+    }    
+    
 
     Em.keys(attrs).forEach(function(property) {
       var bindPath, currentValue, invoker, isBindingMatch, normalized, normalizedPath, observer, propertyName, root, _ref;
@@ -203,7 +210,7 @@
       }
     });
 
-    result = '<%@ id="%@">%@</%@>'.fmt(tagName, elementID, I18n.t(key, attrs), tagName);
+    result = '<%@ id="%@"%@>%@</%@>'.fmt(tagName, elementID, classNames, I18n.t(key, attrs), tagName);
     return new Handlebars.SafeString(result);
   });
 


### PR DESCRIPTION
Sometimes you need class-names, however this may not be the best way to do it. 
It's an attempt to support class attributes/options on the t helper.
