### PR TITLE
Fixes state deprecation recently introduced in Ember.js Master

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -185,7 +185,7 @@
 
         observer = function() {
           var elem, newValue;
-          if (view.get('state') !== 'inDOM') {
+          if ((view._state || view.state) !== 'inDOM') {
             Em.removeObserver(root, normalizedPath, invoker);
             return;
           }


### PR DESCRIPTION
View `_state` should be used instead of `state`

https://github.com/emberjs/ember.js/commit/3d1d53485cfc4056edd73eefaaaac2b6be74d77a
