### PR TITLE
Make i18n.js play nicely with ember-cli (retry)

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -85,7 +85,7 @@
       };
     } else {
       return function cannotCompileTemplate(template) {
-        error('The default Ember.I18n.compile function requires the full Handlebars. Either include the full Handlebars or override Ember.I18n.compile.');
+        throw new Ember.Error('The default Ember.I18n.compile function requires the full Handlebars. Either include the full Handlebars or override Ember.I18n.compile.');
       };
     }
   }());
@@ -160,7 +160,7 @@
     };
   })();
 
-  Handlebars.registerHelper('t', function(key, options) {
+  Ember.Handlebars.registerHelper('t', function(key, options) {
     var attrs, context, data, elementID, result, tagName, view;
     context = this;
     attrs = options.hash;
@@ -204,7 +204,7 @@
     });
 
     result = '<%@ id="%@">%@</%@>'.fmt(tagName, elementID, I18n.t(key, attrs), tagName);
-    return new Handlebars.SafeString(result);
+    return new Ember.Handlebars.SafeString(result);
   });
 
   var attrHelperFunction = function(options) {
@@ -218,10 +218,10 @@
       return result.push('%@="%@"'.fmt(property, translatedValue));
     });
 
-    return new Handlebars.SafeString(result.join(' '));
+    return new Ember.Handlebars.SafeString(result.join(' '));
   };
 
-  Handlebars.registerHelper('translateAttr', attrHelperFunction);
-  Handlebars.registerHelper('ta', attrHelperFunction);
+  Ember.Handlebars.registerHelper('translateAttr', attrHelperFunction);
+  Ember.Handlebars.registerHelper('ta', attrHelperFunction);
 
 }).call(undefined, this);


### PR DESCRIPTION
I ran into some issues when using ember-i18n with ember-cli. While the development mode with "ember serve" would work flawlessly, using "ember build --environment=production" would raise a couple of errors in the compiled output.

I tracked them down and modified my version of i18n.js --- here's the changes for everybody.
(I am using Ember 1.6 beta and ember-cli 0.0.28)

---

Line 88: use `throw new Ember.Error` instead of undefined error function

Lines 163, 227, 228: use `Ember.Handlebars.registerHelper` instead of Handlebars.registerHelper. This makes Ember find the i18n helpers in the compiled output.

Lines 207, 221: use `Ember.Handlebars.SafeString` instead of vanilla Handlebars. This fixes wrongly escaped output.

One note: You will still need to include the vanilla Handlebars library. I was unable to get i18n.js to use the Ember.Handlebars.compile function (the check in line 82 returns false).
In the Brocfile.js (from ember-cli) add `app.import( 'vendor/handlebars/handlebars.js' );` 

With these changes, ember-i18n still works as expected in a normal environment and now also works well in an ember-cli environment.

Cheers!
Marcus
