### PR TITLE
{{t}} supports postfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ yields
 ```
 if `user.getPath('followers.count')` returns `2`.
 
+#### Extends translation key with suffix
+
+```html
+<h2>{{t "button.add_user" translationSuffix="title"}}</h2>
+```
+yields
+```html
+<h2><span id="i18n-123">Add a user</span></h2>
+```
+as tranlation key is now `button.add_user.title`.
+
+#### Extends translation key with bound property
+
+```html
+<h2>{{t "button.add_user" translationSuffixBinding="view.buttonType"}}</h2>
+```
+yields
+```html
+<h2><span id="i18n-123">Saving...</span></h2>
+```
+if `view.get('buttonType')` returns `disabled`,
+then the translation key is `button.add_user.disabled`.
+
 #### Translate properties on any object:
 
 The `Em.I18n.TranslateableProperties` mixin automatically translates

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -103,6 +103,7 @@
     t: function(key, context) {
       var template;
       if (context == null) context = {};
+      if (context.translationSuffix) key = [key, context.translationSuffix].join('.');
       template = I18n.template(key, context.count);
       return template(context);
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "mocha": "~1.9.0",
     "chai": "~1.6.0",
-    "mocha-phantomjs": "~2.0.1",
+    "mocha-phantomjs": "~3.5",
     "jshint": "~2.0.1",
     "handlebars": "~1.0.11"
   }

--- a/spec/spec_support.js
+++ b/spec/spec_support.js
@@ -26,7 +26,8 @@
       'foos.other': 'All {{count}} Foos',
       'bars.all': 'All {{count}} Bars',
       baz: {
-        qux: 'A qux appears'
+        qux: 'A qux appears',
+        foo: 'A foo appears'
       },
       fum: {
         one: 'A fum',

--- a/spec/translateHelperSpec.js
+++ b/spec/translateHelperSpec.js
@@ -100,6 +100,28 @@ describe('{{t}}', function() {
       expect(view.$().text()).to.equal('A Foobar named IPA');
     });
   });
+
+  it('responds to postfix attribute', function() {
+    var view = this.renderTemplate('{{t "baz" translationSuffix="qux"}}');
+
+    expect(view.$().text()).to.equal('A qux appears');
+  });
+
+  it('responds to updates on bound postfix attribute', function() {
+    var view = this.renderTemplate('{{t "baz" translationSuffixBinding="view.suffix"}}', {
+      suffix: 'qux'
+    });
+
+    expect(view.$().text()).to.equal('A qux appears');
+
+    Ember.run(function() {
+      view.set('suffix', 'foo');
+    });
+
+    Ember.run(function() {
+      expect(view.$().text()).to.equal('A foo appears');
+    });
+  });
 });
 
 describe('{{{t}}}', function() {


### PR DESCRIPTION
A `postfix` attribute for `{{t}}` helper can be used as a simple shorthand for when we want to modify translation key dynamically. It can be used for example while iterating through a list of object with some categorization property and generating a different translation key based on this property. 

I used this pattern quite a lot in my apps so maybe other guys will like it too.

Let me know if this can be improved in anyway
