### PR TITLE
Removing Handlebars dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@ Internationalization for Ember
 
 ### Requirements
 
-Set `Ember.I18n.translations` to an object containing your translation
-information. If the values of `Ember.I18n.translations` are `Function`s,
-they will be used as-is; if they are `String`s, they will first be
-compiled via `Ember.I18n.compile`, which defaults to using
-`Handlebars.compile`. (That means that if you haven't precompiled your
-translations, you'll need to include the full Handlebars, not just
-`handlebars-runtime.js` in your application.)
-
 If you want to support inflection based on `count`, you will
 also need to include the
 [CLDR.js pluralization library](https://github.com/jamesarosen/CLDR.js)

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "cldr": "^1.0",
     "jquery": ">=1.7 <3",
-    "handlebars": "^1.0",
     "ember": "^1.0"
   },
   "scripts": {

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -1,8 +1,7 @@
-(function(window) {
+(function() {
   var I18n, assert, findTemplate, get, set, isBinding, lookupKey, pluralForm,
-      PlainHandlebars, EmHandlebars, keyExists, compileTemplate;
+      EmHandlebars, keyExists, compileTemplate;
 
-  PlainHandlebars = window.Handlebars;
   EmHandlebars = Ember.Handlebars;
   get = EmHandlebars.get;
   set = Ember.set;
@@ -66,17 +65,13 @@
     }
   }
 
-  compileTemplate = (function() {
-    if (typeof PlainHandlebars.compile === 'function') {
-      return function compileWithHandlebars(template) {
-        return PlainHandlebars.compile(template);
-      };
-    } else {
-      return function cannotCompileTemplate() {
-        throw new Ember.Error('The default Ember.I18n.compile function requires the full Handlebars. Either include the full Handlebars or override Ember.I18n.compile.');
-      };
-    }
-  }());
+  compileTemplate = function (template) {
+    return function (data) {
+      return template.replace(/\{\{(.*?)\}\}/g, function(i, match) {
+        return data[match];
+      });
+    };
+  };
 
   I18n = Ember.Evented.apply({
     compile: compileTemplate,
@@ -206,4 +201,4 @@
   EmHandlebars.registerHelper('translateAttr', attrHelperFunction);
   EmHandlebars.registerHelper('ta', attrHelperFunction);
 
-}).call(undefined, this);
+}).call(undefined);


### PR DESCRIPTION
This PR replace Handlebars dependency by simple templating function. The code isn't getting any bigger but it may loose some of it's previous flexibility provided by `Handlebars.compile`. For now the test suite is passing, but there may be some edge cases. Please consider if it is worth to go this way.
