### PR TITLE
Removed deprecation warning for those who've opt-in to I18N_COMPILE_WITHOUT_HANDLEBARS

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -68,7 +68,7 @@
   }
 
   compileWithHandlebars = (function() {
-    Ember.warn("Ember.I18n will no longer include Handlebars compilation by default in the future; instead, it will supply its own default compiler. Set Ember.I18n.I18N_COMPILE_WITHOUT_HANDLEBARS to true to opt-in now.");
+    Ember.warn("Ember.I18n will no longer include Handlebars compilation by default in the future; instead, it will supply its own default compiler. Set Ember.ENV.I18N_COMPILE_WITHOUT_HANDLEBARS to true to opt-in now.",  Ember.ENV.I18N_COMPILE_WITHOUT_HANDLEBARS !== undefined);
 
     if (typeof PlainHandlebars.compile === 'function') {
       return function compileWithHandlebars(template) {


### PR DESCRIPTION
I also fixed a typo in the warning message. Changing: `Ember.I18n...` to `Ember.ENV...` in the message.

Please let me know if you have any concerns with this change. I made it because we had opt-in and were confused about seeing the warning. I believe ember typically does not warn about feature deprecation if you're not using that particular feature.

I'd be happy to add rebase this commit and add a point release version if you'd like (2.1.1).
