### PR TITLE
Remove check for Ember.I18n.fire

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -39,7 +39,7 @@
         result = I18n.translations[key] = function() { return "Missing translation: " + key; };
         result._isMissing = true;
         warn("Missing translation: " + key);
-        I18n[(typeof I18n.trigger === 'function' ? 'trigger' : 'fire')]('missing', key); //Support 0.9 style .fire
+        I18n.trigger('missing', key);
       }
     }
 


### PR DESCRIPTION
Ember.I18n no longer supports Ember 0.9.x, so Ember.Evented will always defined `trigger`, not `fire`. Thus, we don't need to check which one to call.

cf #117, #121

cc @workmanw @zelgerj @locks
