### PR TITLE
{{t}} helper warns if key parameter is unquoted

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -195,6 +195,8 @@
     var tagName = attrs.tagName;
     delete attrs.tagName;
 
+    warn("Ember.I18n t helper called with unquoted key: %@. In the future, this will be treated as a bound property, not a string literal.".fmt(key), options.types[0] === 'STRING');
+
     var translationView = TranslationView.create({
       context: attrs,
       translationKey: key,

--- a/spec/translateHelperSpec.js
+++ b/spec/translateHelperSpec.js
@@ -13,6 +13,19 @@ describe('{{t}}', function() {
     });
   });
 
+  it('emits a warning on unquoted keys', function() {
+    var spy = sinon.spy(Ember.Logger, 'warn');
+
+    var view = this.renderTemplate('{{t foo.bar}}');
+
+    Ember.run(function() {
+      expect(spy.callCount).to.equal(1);
+      expect(spy.lastCall.args[0]).to.match(/unquoted/);
+      expect(spy.lastCall.args[0]).to.match(/foo\.bar/);
+      expect(view.$().text()).to.equal('A Foobar');
+    });
+  });
+
   it('interpolates values', function() {
     var view = this.renderTemplate('{{t "bars.all" count="597"}}');
 


### PR DESCRIPTION
The helper currently treats `{{t "some.key"}}` and `{{t some.key}}` the same -- both use the "some.key" translation. In the future, we would like to support bound keys like `{{t user.type}}` or even `{{t "message" "welcome" user.type}}`.

Thus, we emit a warning during a transitionary period.

References:
- https://github.com/jamesarosen/ember-i18n/issues/41
- https://github.com/jamesarosen/ember-i18n/issues/66
- https://github.com/jamesarosen/ember-i18n/pull/113
