### PR TITLE
Execute Ember.uuid if it's a function

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -158,7 +158,7 @@
 
   function uniqueElementId() {
     if (Ember.typeOf(Ember.uuid) === 'function') {
-      return ++Ember.uuid();
+      return Ember.uuid();
     } else {
       return ++Ember.uuid;
     }


### PR DESCRIPTION
In Ember 1.7.0-beta.5, `Ember.uuid` is actually a function. Right now everywhere in our app (which is running `1.7.0-beta.5`) all of our translated strings have an id of `i18n-NaN`. This resolves the issue.
