### PR TITLE
Internal uuid Generation

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -159,7 +159,8 @@
   // Generate a universally unique id
   var _uuid = 0;
   function uniqueElementId() {
-    return 'i18n-' + ++_uuid;
+    var i = ++_uuid;
+    return 'i18n-' + i;
   }
 
   var TranslationView = Ember._MetamorphView.extend({


### PR DESCRIPTION
Since Ember 1.7.0 `Ember.uuid` is internal.

Also, the existing solution generated number-only IDs, which doesn't always play nice with HTML4 (HTML5 is more permissive).

This PR fixes both issues.

RELATED
- https://github.com/jamesarosen/ember-i18n/pull/133
- http://stackoverflow.com/questions/70579/what-are-valid-values-for-the-id-attribute-in-html
- https://github.com/emberjs/ember.js/commit/1c7b35c274572fea0bf9b89d6ee689f5ae78445d
