### PR TITLE
Select Template Compiler on Use

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -1,7 +1,6 @@
 (function(window) {
   var I18n, assert, findTemplate, get, set, isBinding, lookupKey, pluralForm,
-      PlainHandlebars, EmHandlebars, keyExists,
-      compileTemplate, compileWithHandlebars;
+      PlainHandlebars, EmHandlebars, keyExists;
 
   PlainHandlebars = window.Handlebars;
   EmHandlebars = Ember.Handlebars;
@@ -66,8 +65,30 @@
     }
   }
 
-  compileWithHandlebars = (function() {
-    if (Ember.ENV.I18N_COMPILE_WITHOUT_HANDLEBARS === undefined) {
+  var compileImplementation;
+
+  function compileTemplate(template) {
+    if (compileImplementation === undefined) {
+      compileImplementation = selectCompileImplementation();
+    }
+
+    return compileImplementation(template);
+  }
+
+  function selectCompileImplementation() {
+    var flag = Ember.ENV.I18N_COMPILE_WITHOUT_HANDLEBARS;
+
+    if (flag === true) {
+      return function compileWithoutHandlebars(template) {
+        return function (data) {
+          return template.replace(/\{\{(.*?)\}\}/g, function(i, match) {
+            return data[match];
+          });
+        };
+      };
+    }
+
+    if (flag === undefined) {
       warn("Ember.I18n will no longer include Handlebars compilation by default in the future; instead, it will supply its own default compiler. Set Ember.ENV.I18N_COMPILE_WITHOUT_HANDLEBARS to true to opt-in now.");
     }
 
@@ -80,20 +101,6 @@
         throw new Ember.Error('The default Ember.I18n.compile function requires the full Handlebars. Either include the full Handlebars or override Ember.I18n.compile.');
       };
     }
-  }());
-
-  function compileWithoutHandlebars(template) {
-    return function (data) {
-      return template.replace(/\{\{(.*?)\}\}/g, function(i, match) {
-        return data[match];
-      });
-    };
-  }
-
-  if (Ember.ENV.I18N_COMPILE_WITHOUT_HANDLEBARS === true) {
-    compileTemplate = compileWithoutHandlebars;
-  } else {
-    compileTemplate = compileWithHandlebars;
   }
 
   I18n = Ember.Evented.apply({
@@ -155,7 +162,7 @@
   Ember.I18n = I18n;
 
   isBinding = /(.+)Binding$/;
-  
+
   // Generate a universally unique id
   var _uuid = 0;
   function uniqueElementId() {


### PR DESCRIPTION
Users of Ember-CLI were having trouble setting `Ember.ENV.I18N_COMPILE_WITHOUT_HANDLEBARS` before Ember-I18n loads. This commit changes the default `Ember.I18n.compile` to select its implementation lazily on first use so the users' settings have had a chance to take effect.

Closes #139
