### PR TITLE
Allow customization of the missing translation message

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -35,7 +35,7 @@
 
     if (setOnMissing) {
       if (result == null) {
-        result = I18n.translations[key] = function() { return "Missing translation: " + key; };
+        result = I18n.translations[key] = function() { return I18n.missingMessage(key); };
         result._isMissing = true;
         I18n.trigger('missing', key);
       }
@@ -133,6 +133,10 @@
     },
 
     exists: keyExists,
+
+    missingMessage: function(key) {
+      return "Missing translation: " + key; 
+    },
 
     TranslateableProperties: Ember.Mixin.create({
       init: function() {

--- a/spec/spec_support.js
+++ b/spec/spec_support.js
@@ -21,6 +21,7 @@
   beforeEach(function() {
     this.renderTemplate = renderTemplate.bind(this);
     this.originalTranslations = Ember.I18n.translations;
+    this.originalMissingMessage = Ember.I18n.missingMessage;
 
     Ember.I18n.translations = {
       'foo.bar': 'A Foobar',
@@ -49,6 +50,7 @@
     }
 
     Ember.I18n.translations = this.originalTranslations;
+    Ember.I18n.missingMessage = this.originalMissingMessage;
     CLDR.defaultLanguage = null;
   });
 

--- a/spec/tSpec.js
+++ b/spec/tSpec.js
@@ -37,6 +37,11 @@ describe('Ember.I18n.t', function() {
     expect(Ember.I18n.t('nothing.here')).to.equal('Missing translation: nothing.here');
   });
 
+  it('warns with a custom message', function() {
+    Ember.I18n.missingMessage = function(key) { return "there.is." + key + ".to.see"; };
+    expect(Ember.I18n.t('nothing.here')).to.equal('there.is.nothing.here.to.see');
+  });
+
   describe('missing event', function() {
     var spy;
 


### PR DESCRIPTION
I was tempted to make this a function, rather than a formatted string, but there's already an event for that.
