### PR TITLE
{{t}} helper should update multiple bound properties.

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -236,7 +236,7 @@
       var _ref = [normalized.root, normalized.path], root = _ref[0], normalizedPath = _ref[1];
 
       var observer = function() {
-        if (translationView.$() == null) {
+        if (translationView.$() == null && ((translationView._state || translationView.state) !== 'preRender')) {
           Ember.removeObserver(root, normalizedPath, invoker);
           return;
         }

--- a/spec/spec_support.js
+++ b/spec/spec_support.js
@@ -31,6 +31,7 @@
       'foos.one': 'One Foo',
       'foos.other': 'All {{count}} Foos',
       'bars.all': 'All {{count}} Bars',
+      'bars.x_of_y': '{{count}} of {{total}} Bars',
       baz: {
         qux: 'A qux appears'
       },

--- a/spec/translateHelperSpec.js
+++ b/spec/translateHelperSpec.js
@@ -54,6 +54,21 @@ describe('{{t}}', function() {
     });
   });
 
+  it('responds to updates on multiple bound properties', function() {
+    var view = this.renderTemplate('{{t "bars.x_of_y" countBinding="view.count" totalBinding="view.total"}}', { count: 3, total: 4 });
+
+    Ember.run(function() {
+      view.setProperties({
+        count: 4,
+        total: 5
+      });
+    });
+
+    Ember.run(function() {
+      expect(view.$().text()).to.equal('4 of 5 Bars');
+    });
+  });
+
   it('does not error due to bound properties during a rerender', function() {
     var view = this.renderTemplate('{{t "bars.all" countBinding="view.count"}}', { count: 3 });
 


### PR DESCRIPTION
The first observed property triggers a rerender, effectively removing it
from the DOM until the render loop runs.  The second observer examines
the view, finds that view.$() returns null, and assumes it's safe to
destroy itself.

To work around the above, keep the observer around when the view is in
"preRender" state.