### PR TITLE
Makefile: check for node, npm, phantomjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - WITHOUT_HANDLEBARS=true JQUERY_VERSION=2.0.3 EMBER_VERSION=release HANDLEBARS_VERSION=1.3.0
   - JQUERY_VERSION=1.11.0 EMBER_VERSION=beta HANDLEBARS_VERSION=1.3.0
   - WITHOUT_HANDLEBARS=true JQUERY_VERSION=1.11.0 EMBER_VERSION=beta HANDLEBARS_VERSION=1.3.0
-install: make npm_install vendor_install
+install: make development_dependencies vendor_install
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ CHECK = \033[32m✓\033[m
 
 all: clean test_stables
 
-jshint: npm_install
+jshint: development_dependencies
 	@./node_modules/jshint/bin/jshint lib/*.js spec/*Spec.js script/*.js
 	@echo "$(CHECK) JSHint OK"
 
-test_stables: jshint npm_install vendor_install
+test_stables: jshint development_dependencies vendor_install
 	JQUERY_VERSION=1.9.1 EMBER_VERSION=1.0.1 HANDLEBARS_VERSION=1.1.0 ./script/run.js
 	JQUERY_VERSION=1.11.0 EMBER_VERSION=release HANDLEBARS_VERSION=1.3.0 ./script/run.js
 	JQUERY_VERSION=2.0.3 EMBER_VERSION=release HANDLEBARS_VERSION=1.3.0 ./script/run.js
@@ -14,21 +14,17 @@ test_stables: jshint npm_install vendor_install
 	WITHOUT_HANDLEBARS=true JQUERY_VERSION=1.11.0 EMBER_VERSION=release HANDLEBARS_VERSION=1.3.0 ./script/run.js
 	WITHOUT_HANDLEBARS=true JQUERY_VERSION=2.0.3 EMBER_VERSION=release HANDLEBARS_VERSION=1.3.0 ./script/run.js
 
-test_prereleases: jshint npm_install vendor_install
+test_prereleases: jshint development_dependencies vendor_install
 	JQUERY_VERSION=1.11.0 EMBER_VERSION=beta HANDLEBARS_VERSION=1.3.0 ./script/run.js
 	WITHOUT_HANDLEBARS=true JQUERY_VERSION=1.11.0 EMBER_VERSION=beta HANDLEBARS_VERSION=1.3.0 ./script/run.js
 
 # Run the tests against the current environment only; don't run any prerequisites like
 # dependency installation or JSHint checks.
-test:
+test: development_dependencies
 	@echo "Running tests with jQuery $$JQUERY_VERSION, Ember $$EMBER_VERSION, and Handlebars $$HANDLEBARS_VERSION"
 	@./script/run.js
 
-npm_install:
-	@npm install 2>&1 1>/dev/null
-	@echo "$(CHECK) Installed development dependencies"
-
-vendor_install:
+vendor_install: development_dependencies
 	@./script/fetch_vendor.js
 	@echo "$(CHECK) Fetched vendor dependencies"
 
@@ -42,4 +38,11 @@ realclean: clean
 	@rm -f vendor/jquery*
 	@echo "$(CHECK) Cleaned *everyhing*"
 
-.PHONY: jshint test_stables test_prereleases test npm_install vendor_install clean realclean
+development_dependencies:
+	@which node > /dev/null || (echo "Could not find node on path" && false)
+	@which npm > /dev/null || (echo "Could not find npm on path" && false)
+	@which phantomjs > /dev/null || (echo "Could not find phantomjs on path" && false)
+	@npm install 2>&1 1>/dev/null
+	@echo "$(CHECK) Development dependencies OK"
+
+.PHONY: jshint test_stables test_prereleases test vendor_install clean realclean development_dependencies


### PR DESCRIPTION
This commit moves the `npm install` command into a new `development_dependencies` target that also ensures that `node`, `npm`, and `phantomjs` are all available on the path.

Closes #137
