### PR TITLE
translateHelperSpec: restore Ember.Logger.warn

### DIFF
--- a/spec/translateHelperSpec.js
+++ b/spec/translateHelperSpec.js
@@ -1,8 +1,15 @@
 describe('{{t}}', function() {
 
+  var warn;
+
   beforeEach(function() {
     // compatibility mode:
     Ember.FEATURES.I18N_TRANSLATE_HELPER_SPAN = true;
+    warn = sinon.spy(Ember.Logger, 'warn');
+  });
+
+  afterEach(function() {
+    warn.restore();
   });
 
   it('outputs simple translated strings', function() {
@@ -14,14 +21,13 @@ describe('{{t}}', function() {
   });
 
   it('emits a warning on unquoted keys', function() {
-    var spy = sinon.spy(Ember.Logger, 'warn');
 
     var view = this.renderTemplate('{{t foo.bar}}');
 
     Ember.run(function() {
-      expect(spy.callCount).to.equal(1);
-      expect(spy.lastCall.args[0]).to.match(/unquoted/);
-      expect(spy.lastCall.args[0]).to.match(/foo\.bar/);
+      expect(warn.callCount).to.equal(1);
+      expect(warn.lastCall.args[0]).to.match(/unquoted/);
+      expect(warn.lastCall.args[0]).to.match(/foo\.bar/);
       expect(view.$().text()).to.equal('A Foobar');
     });
   });


### PR DESCRIPTION
We were spying on Ember.Logger.warn in the beforeEach, but never restoring it to its native behavior in an afterEach.
