### PR TITLE
Internalize pluralization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ test: development_dependencies
 	@./script/run.js
 
 vendor_install: development_dependencies
+	@mkdir -p ./vendor
 	@./script/fetch_vendor.js
 	@echo "$(CHECK) Fetched vendor dependencies"
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Handlebars. The older Handlebars-based compiler has been deprecated and
 will be removed in a future release.
 
 If you want to support inflection based on `count`, you will
-also need to include the
-[CLDR.js pluralization library](https://github.com/jamesarosen/CLDR.js)
-and set `CLDR.defaultLanguage` to the current locale code (e.g. "de").
+also need to include Ember-I18n's pluralization support (`lib/i18n-plurals.js`)
+*after* the Ember-I18n core (`lib/i18n.js`) itself and set `Ember.I18n.locale`
+to the current locale code (e.g. "de").
 
 #### New: I18N_TRANSLATE_HELPER_SPAN
 

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
   "description": "I18n support for Ember.js",
   "main": [ "lib/i18n.js" ],
   "dependencies": {
-    "cldr": "^1.0",
     "jquery": ">=1.7 <3",
     "handlebars": "^1.0",
     "ember": ">=1.0 <1.9"

--- a/lib/i18n-plurals.js
+++ b/lib/i18n-plurals.js
@@ -1,5 +1,7 @@
 (function(globals) {
 
+  Ember.assert('i18n-plurals must be included after i18n.', globals.Ember.I18n != null);
+
   // CLDR Pluralization Data
   // see http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html
 
@@ -33,7 +35,7 @@
     'az', 'bm', 'my', 'zh', 'dz', 'ka', 'hu', 'ig', 'id', 'ja', 'jv', 'kea',
     'kn', 'km', 'ko', 'ses', 'lo', 'kde', 'ms', 'fa', 'root', 'sah', 'sg',
     'ii', 'th', 'bo', 'to', 'tr', 'vi', 'wo', 'yo'
-  ], function(n) {
+  ], function(/* n */) {
     return Other;
   });
 
@@ -204,37 +206,35 @@
     }
   });
 
-  if ( globals.CLDR == null ) { globals.CLDR = {}; }
-
-  var CLDR = globals.CLDR;
-
   // Look up the proper plural key for a count and language.
-  // If CLDR.defaultLanguage is set, language is optional.
+  // If Ember.I18n.locale is set, language is optional.
   //
   // For example:
   //
-  //     CLDR.pluralForm(0, 'en');     // => 'other'
-  //     CLDR.pluralForm(1, 'en-US');  // => 'one'
-  //     CLDR.pluralForm(2.383, 'fr'); // => 'other'
-  //     CLDR.pluralForm(1, 'zh');     // => 'other'
-  //     CLDR.pluralForm(26, 'uk');    // => 'many'
+  //     Ember.I18n.pluralForm(0, 'en');     // => 'other'
+  //     Ember.I18n.pluralForm(1, 'en-US');  // => 'one'
+  //     Ember.I18n.pluralForm(2.383, 'fr'); // => 'other'
+  //     Ember.I18n.pluralForm(1, 'zh');     // => 'other'
+  //     Ember.I18n.pluralForm(26, 'uk');    // => 'many'
   //
-  // @return [String] the proper key (one of `CLDR.pluralForm.Zero`,
+  // @return [String] the proper key (one of `Ember.I18n.pluralForm.Zero`,
   //   `.One`, `.Two`, `.Few`, `.Many`, or `.Other`).
-  CLDR.pluralForm = function(count, language) {
-    if (count == null) { throw new Error("CLDR.pluralForm requires a count"); }
-    language = language || CLDR.defaultLanguage;
-    if (language == null) { throw new Error("CLDR.pluralForm requires a language"); }
+  function pluralForm(count, language) {
+    if (count == null) { throw new Error("Ember.I18n.pluralForm requires a count"); }
+    language = language || Ember.I18n.locale || (globals.CLDR && globals.CLDR.defaultLanguage);
+    if (language == null) { throw new Error("Ember.I18n.pluralForm requires a language"); }
     language = language.replace(/^(\w\w\w?)-?.*/, "$1");
-    if (Data[language] == null) { throw new Error("No CLDR pluralization information for " + language); }
-    return Data[language].call(CLDR, +count);
-  };
+    if (Data[language] == null) { throw new Error("No pluralization information for " + language); }
+    return Data[language].call(undefined, +count);
+  }
 
-  CLDR.pluralForm.Zero  = Zero;
-  CLDR.pluralForm.One   = One;
-  CLDR.pluralForm.Two   = Two;
-  CLDR.pluralForm.Few   = Few;
-  CLDR.pluralForm.Many  = Many;
-  CLDR.pluralForm.Other = Other;
+  pluralForm.Zero  = Zero;
+  pluralForm.One   = One;
+  pluralForm.Two   = Two;
+  pluralForm.Few   = Few;
+  pluralForm.Many  = Many;
+  pluralForm.Other = Other;
+
+  Ember.I18n.pluralForm = pluralForm;
 
 }(this));

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -1,5 +1,5 @@
 (function(window) {
-  var I18n, assert, findTemplate, get, set, isBinding, lookupKey, pluralForm,
+  var I18n, assert, findTemplate, get, set, isBinding, lookupKey,
       PlainHandlebars, EmHandlebars, keyExists;
 
   PlainHandlebars = window.Handlebars;
@@ -9,12 +9,6 @@
   assert = Ember.assert;
 
   function warn(msg) { Ember.Logger.warn(msg); }
-
-  if (typeof CLDR !== "undefined" && CLDR !== null) pluralForm = CLDR.pluralForm;
-
-  if (pluralForm == null) {
-    warn("CLDR.pluralForm not found. Ember.I18n will not support count-based inflection.");
-  }
 
   lookupKey = function(key, hash) {
     var firstKey, idx, remainingKeys;
@@ -104,6 +98,8 @@
   }
 
   I18n = Ember.Evented.apply({
+    pluralForm: undefined,
+
     compile: compileTemplate,
 
     translations: {},
@@ -117,8 +113,8 @@
 
     template: function(key, count) {
       var interpolatedKey, result, suffix;
-      if ((count != null) && (pluralForm != null)) {
-        suffix = pluralForm(count);
+      if ((count != null) && (I18n.pluralForm != null)) {
+        suffix = I18n.pluralForm(count);
         interpolatedKey = "%@.%@".fmt(key, suffix);
         result = findTemplate(interpolatedKey, false);
       }
@@ -270,5 +266,10 @@
 
   EmHandlebars.registerHelper('translateAttr', attrHelperFunction);
   EmHandlebars.registerHelper('ta', attrHelperFunction);
+
+  if (typeof CLDR !== "undefined") {
+    Ember.deprecate("CLDR.js has been deprecated; use Ember-I18n's i18n-plurals.js instead.");
+    Ember.I18n.pluralForm = CLDR.pluralForm;
+  }
 
 }).call(undefined, this);

--- a/spec/spec_support.js
+++ b/spec/spec_support.js
@@ -40,7 +40,7 @@
       }
     };
 
-    CLDR.defaultLanguage = 'ksh';
+    Ember.I18n.locale = 'ksh';
   });
 
   afterEach(function() {
@@ -51,7 +51,7 @@
 
     Ember.I18n.translations = this.originalTranslations;
     Ember.I18n.missingMessage = this.originalMissingMessage;
-    CLDR.defaultLanguage = null;
+    Ember.I18n.locale = null;
   });
 
 }());

--- a/spec/suite.hdbs
+++ b/spec/suite.hdbs
@@ -9,8 +9,8 @@
         Ember.ENV.I18N_COMPILE_WITHOUT_HANDLEBARS = {{withoutHandlebars}};
       </script>
     {{/if}}
-    <script src="../vendor/cldr-1.0.0.js"></script>
     <script src="../lib/i18n.js"></script>
+    <script src="../lib/i18n-plurals.js"></script>
     <link rel="stylesheet" href="../node_modules/mocha-phantomjs/node_modules/mocha/mocha.css" />
   </head>
   <body>


### PR DESCRIPTION
- remove dependency on `CLDR.js`
- add `lib/i18n-plurals.js` with pluralization logic, to be included after `lib/i18n.js`
- add deprecation warning if `window.CLDR` is defined
- look for current locale in `Ember.I18n.currentLocale` before falling back on `CLDR.defaultLanguage`
- Change README to describe new process to add pluralization support

Closes #46

See also #49
