### PR TITLE
Drop support for CLDR.js

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,7 +7,6 @@
   "globals": {
     "console": false,
 
-    "CLDR": false,
     "Ember": false,
     "jQuery": false,
 

--- a/lib/i18n-plurals.js
+++ b/lib/i18n-plurals.js
@@ -221,7 +221,7 @@
   //   `.One`, `.Two`, `.Few`, `.Many`, or `.Other`).
   function pluralForm(count, language) {
     if (count == null) { throw new Error("Ember.I18n.pluralForm requires a count"); }
-    language = language || Ember.I18n.locale || (globals.CLDR && globals.CLDR.defaultLanguage);
+    language = language || Ember.I18n.locale;
     if (language == null) { throw new Error("Ember.I18n.pluralForm requires a language"); }
     language = language.replace(/^(\w\w\w?)-?.*/, "$1");
     if (Data[language] == null) { throw new Error("No pluralization information for " + language); }

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -239,9 +239,4 @@
   EmHandlebars.registerHelper('translateAttr', attrHelperFunction);
   EmHandlebars.registerHelper('ta', attrHelperFunction);
 
-  if (typeof CLDR !== "undefined") {
-    Ember.deprecate("CLDR.js has been deprecated; use Ember-I18n's i18n-plurals.js instead.");
-    Ember.I18n.pluralForm = CLDR.pluralForm;
-  }
-
 }).call(undefined, this);


### PR DESCRIPTION
- JSHint: CLDR is no longer defined
- `Ember.I18n.locale` no longer falls back to `CLDR.defaultLanguage`
- `Ember.I18n.pluralForm` no longer defaults to `CLDR.pluralForm`
