### PR TITLE
Using Ember.get for interpolations

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -61,7 +61,7 @@
   function compileTemplate(template) {
     return function(data) {
       return template.replace(/\{\{(.*?)\}\}/g, function(i, match) {
-        return data[match];
+        return get(data, match);
       });
     };
   }

--- a/spec/spec_support.js
+++ b/spec/spec_support.js
@@ -26,6 +26,7 @@
     Ember.I18n.translations = {
       'foo.bar': 'A Foobar',
       'foo.bar.named': 'A Foobar named {{name}}',
+      'foo.bar.structured.named': 'A Foobar named {{contact.name}}',
       'foo.save.disabled': 'Saving Foo...',
       'foos.zero': 'No Foos',
       'foos.one': 'One Foo',

--- a/spec/tSpec.js
+++ b/spec/tSpec.js
@@ -9,6 +9,12 @@ describe('Ember.I18n.t', function() {
     })).to.equal('A Foobar named Sue');
   });
 
+  it('interpolates structures correctly', function() {
+    expect(Ember.I18n.t('foo.bar.structured.named', {
+      contact: { name: 'Sue' }
+    })).to.equal('A Foobar named Sue');
+  });
+
   it('uses the "zero" form when the language calls for it', function() {
     expect(Ember.I18n.t('foos', {
       count: 0


### PR DESCRIPTION
For the following structured interpolation functionality:

```
{{t "User {{contact.firstName}} {{contact.lastName}}" contact=xxx}}
```

While till this patch this has to be done as follows:

```
{{t "User {{firstName}} {{lastName}}" firstName=xxx.firstName lastName=xxx.lastName}}
```
