### PR TITLE
Escape interpolations by default

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -58,11 +58,17 @@
     }
   }
 
+  var escapeExpression = EmHandlebars.Utils.escapeExpression;
+
   function compileTemplate(template) {
     return function(data) {
-      return template.replace(/\{\{(.*?)\}\}/g, function(i, match) {
-        return get(data, match);
-      });
+      return template
+        .replace(/\{\{\{(.*?)\}\}\}/g, function(i, match) {
+          // tripple curlies -> no-escaping
+          return get(data, match);
+        }).replace(/\{\{(.*?)\}\}/g, function(i, match) {
+         return escapeExpression( get(data, match) );
+        });
     };
   }
 

--- a/spec/spec_support.js
+++ b/spec/spec_support.js
@@ -25,8 +25,9 @@
 
     Ember.I18n.translations = {
       'foo.bar': 'A Foobar',
-      'foo.bar.named': 'A Foobar named {{name}}',
-      'foo.bar.structured.named': 'A Foobar named {{contact.name}}',
+      'foo.bar.named': 'A Foobar named <span>{{name}}</span>',
+      'foo.bar.named.noEscape': 'A Foobar named <span>{{{link}}}</span>',
+      'foo.bar.named.structured': 'A Foobar named {{contact.name}}',
       'foo.save.disabled': 'Saving Foo...',
       'foos.zero': 'No Foos',
       'foos.one': 'One Foo',

--- a/spec/tSpec.js
+++ b/spec/tSpec.js
@@ -5,12 +5,18 @@ describe('Ember.I18n.t', function() {
 
   it('interpolates', function() {
     expect(Ember.I18n.t('foo.bar.named', {
-      name: 'Sue'
-    })).to.equal('A Foobar named Sue');
+      name: '<Sue>'
+    })).to.equal('A Foobar named <span>&lt;Sue&gt;</span>');
+  });
+
+  it('interpolates escaped', function() {
+    expect(Ember.I18n.t('foo.bar.named.noEscape', {
+      link: '<a href="#">Sue</a>'
+    })).to.equal('A Foobar named <span><a href="#">Sue</a></span>');
   });
 
   it('interpolates structures correctly', function() {
-    expect(Ember.I18n.t('foo.bar.structured.named', {
+    expect(Ember.I18n.t('foo.bar.named.structured', {
       contact: { name: 'Sue' }
     })).to.equal('A Foobar named Sue');
   });


### PR DESCRIPTION
This is in order to get the expected handlebars-like mustache
escaping behavior. Unescaped interpolation made possible via the
common tripple curlies mustache.