### PR TITLE
.travis.yml: tests against Ember-beta and -canary may fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ env:
   - JQUERY_VERSION=2.0.3 EMBER_VERSION=release HANDLEBARS_VERSION=2.0.0
   - JQUERY_VERSION=1.11.0 EMBER_VERSION=beta HANDLEBARS_VERSION=2.0.0
   - JQUERY_VERSION=1.11.0 EMBER_VERSION=canary HANDLEBARS_VERSION=2.0.0
+matrix:
+  allow_failures:
+    - node_js: "0.10"
+      env: JQUERY_VERSION=1.11.0 EMBER_VERSION=beta HANDLEBARS_VERSION=2.0.0
+    - node_js: "0.10"
+      env: JQUERY_VERSION=1.11.0 EMBER_VERSION=canary HANDLEBARS_VERSION=2.0.0
 install: make development_dependencies vendor_install
 before_script:
   - export DISPLAY=:99.0


### PR DESCRIPTION
Ember is moving too rapidly for us to reliably test against the beta and canary versions. It'll be nice to know when those builds fail, but we can't let them stop us from working.
