### PR TITLE
Clean up translated property observers on destroy.

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -109,7 +109,7 @@
     },
 
     TranslateableProperties: Ember.Mixin.create({
-        _translationObserver :  function(sender, key, value){
+        _translationObserver :  function(sender, key){
            set(this, key, I18n.t(this.get(key + 'Translation')));
         },
       init: function() {
@@ -123,7 +123,7 @@
         return result;
       },
       _clearObservers :  function (){
-          eachTranslatedAttribute(this, function(attribute, translation) {
+          eachTranslatedAttribute(this, function(attribute) {
               if(this.hasObserverFor(attribute + 'Translation')){
                 this.removeObserver(attribute + 'Translation', this._translationObserver);
               }

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -109,17 +109,27 @@
     },
 
     TranslateableProperties: Ember.Mixin.create({
+        _translationObserver :  function(sender, key, value){
+           set(this, key, I18n.t(this.get(key + 'Translation')));
+        },
       init: function() {
         var result = this._super.apply(this, arguments);
+
         eachTranslatedAttribute(this, function(attribute, translation) {
-          this.addObserver(attribute + 'Translation', this, function(){
-            set(this, attribute, I18n.t(this.get(attribute + 'Translation')));
-          });
+          this.addObserver(attribute + 'Translation', this,this._translationObserver);
           set(this, attribute, translation);
         });
 
         return result;
-      }
+      },
+      _clearObservers :  function (){
+          eachTranslatedAttribute(this, function(attribute, translation) {
+              if(this.hasObserverFor(attribute + 'Translation')){
+                this.removeObserver(attribute + 'Translation', this._translationObserver);
+              }
+          });
+    }.on('willDestroyElement','willClearRender')
+
     }),
 
     TranslateableAttributes: Ember.Mixin.create({


### PR DESCRIPTION
#188

I couldn't find an event that matched .on('destroy') at http://emberjs.com/api/classes/Ember.View.html  both **willDestroyElement** and **willClearRender** are needed though.