### PR TITLE
Updating jshint version squashes npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chai": "~1.6.0",
     "sinon": "1.10.3",
     "mocha-phantomjs": "~2.0.1",
-    "jshint": "~2.0.1",
+    "jshint": "~2.6",
     "handlebars": "~1.0.11",
     "uglify-js": "^2.4.16"
   }


### PR DESCRIPTION
npm (which gets auto-corrected to "nom", which I almost don't want to fix) doesn't like packages without repository fields in their package.json. jshint 2.0.x didn't have that field; it's been added since then, so an update gets rid of that annoying (but harmless) warning.

Reference: http://stackoverflow.com/q/16827858/306084