### PR TITLE
Minimal ember-cli addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,20 @@ Example using pluralization in the template:
 
 Depending on the locale there could be up to 6 plural forms used, namely: 'zero', 'one', 'two', 'few', 'many', 'other'.
 
+### Using with Ember-cli
+
+Install ember-i18n as node module:
+```
+npm install ember-i18n --save-dev
+```
+
+Run generator to fetch dependencies:
+```
+ember generate ember-i18n
+```
+
+That's it.
+
 ### Limitations
 
  * There is no way to pass interpolations to attribute translations. I can't

--- a/lib/ember-addon/blueprints/ember-i18n/index.js
+++ b/lib/ember-addon/blueprints/ember-i18n/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  normalizeEntityName: function() {
+    // this prevents an error when the entityName is
+    // not specified (since that doesn't actually matter
+    // to us
+  },
+
+  afterInstall: function() {
+    return this.addBowerPackageToProject('ember-i18n');
+  }
+};

--- a/lib/ember-addon/index.js
+++ b/lib/ember-addon/index.js
@@ -9,17 +9,6 @@ module.exports = {
     return path.join(__dirname, 'blueprints');
   },
 
-  config: function(env, config) {
-    return {
-      EmberENV: {
-        FEATURES: {
-          I18N_COMPILE_WITHOUT_HANDLEBARS: true,
-          I18N_TRANSLATE_HELPER_SPAN: false
-        }
-      }
-    }
-  },
-
   included: function(app) {
     this._super.included(app);
 

--- a/lib/ember-addon/index.js
+++ b/lib/ember-addon/index.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var path = require('path');
+
+module.exports = {
+  name: 'ember-i18n',
+
+  blueprintsPath: function() {
+    return path.join(__dirname, 'blueprints');
+  },
+
+  config: function(env, config) {
+    return {
+      EmberENV: {
+        FEATURES: {
+          I18N_COMPILE_WITHOUT_HANDLEBARS: true,
+          I18N_TRANSLATE_HELPER_SPAN: false
+        }
+      }
+    }
+  },
+
+  included: function(app) {
+    this._super.included(app);
+
+    this.app.import(app.bowerDirectory + '/ember-i18n/lib/i18n.js', {
+      exports: {
+        'ember-i18n': [
+          'default'
+        ]
+      }
+    });
+    this.app.import(app.bowerDirectory + '/ember-i18n/lib/i18n-plurals.js');
+  }
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "keywords": [
     "ember",
     "internationalization",
-    "i18n"
+    "i18n",
+    "ember-addon"
   ],
   "author": "James A. Rosen <james.a.rosen@gmail.com>",
   "repository": {
@@ -14,6 +15,9 @@
     "url": "git://github.com/jamesarosen/ember-i18n.git"
   },
   "main": "lib/i18n.js",
+  "ember-addon": {
+    "main": "lib/ember-addon/index.js"
+  },
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
This is a continuation of @chrmod 's work in PR #149. I've rebased it on master and removed the configuration block (because the specified flags are no longer needed). I'm fiddling with installing it in a fork of our app to confirm that it works as advertised, but it seems to install properly.

To try it out: check out this branch into a directory, then run

> `$ npm install /path/to/ember-i18n/ --save-dev`
> `$ ember generate ember-i18n`

It will grab ember-i18n from Bower, so (perhaps ironically) version 2.9 will be installed.