### PR TITLE
Support passing the context to missingMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,35 @@ Example using pluralization in the template:
 
 Depending on the locale there could be up to 6 plural forms used, namely: 'zero', 'one', 'two', 'few', 'many', 'other'.
 
+### Missing translations
+
+When `t` is called with a nonexistent key, it returns the result of calling
+`Ember.I18n.missingMessage` with the key and the context as arguments. The
+default behavior is to return "Missing translation: [key]", but you can
+customize this by overriding `missingMessage`. The below example spits out the
+key along with the values of any arguments that were passed:
+
+```javascript
+Ember.I18n.missingMessage = function(key, context) {
+  var values = Object.keys(context).map(function(key) { return context[key]; });
+  return key + ': ' + (values.join(', '));
+};
+
+Ember.I18n.t('nothing.here', { arg1: 'foo', arg2: 'bar' });
+// => "nothing.here: foo, bar"
+```
+
+When a missing translation is encountered, a `missing` event is also triggered
+on `Ember.I18n`, with the key and the context as arguments. You can use this to
+execute other missing-translation behaviors unrelated to the `missingMessage`,
+such as logging the key somewhere.
+
+```javascript
+Ember.I18n.on('missing', function(key, context) {
+  Ember.Logger.warn("Missing translation: " + key);
+};
+```
+
 ### Using with Ember-cli
 
 Install ember-i18n as node module:

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -97,7 +97,7 @@
           return I18n.missingMessage(key, context);
         };
         template._isMissing = true;
-        I18n.trigger('missing', key);
+        I18n.trigger('missing', key, context);
       }
 
       return template(context);

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -20,17 +20,9 @@
     }
   };
 
-  findTemplate = function(key, setOnMissing) {
+  findTemplate = function(key) {
     assert("You must provide a translation key string, not %@".fmt(key), typeof key === 'string');
     var result = lookupKey(key, I18n.translations);
-
-    if (setOnMissing) {
-      if (result == null) {
-        result = I18n.translations[key] = function() { return I18n.missingMessage(key); };
-        result._isMissing = true;
-        I18n.trigger('missing', key);
-      }
-    }
 
     if ((result != null) && !Ember.$.isFunction(result)) {
       result = I18n.translations[key] = I18n.compile(result);
@@ -90,15 +82,24 @@
       if ((count != null) && (I18n.pluralForm != null)) {
         suffix = I18n.pluralForm(count);
         interpolatedKey = "%@.%@".fmt(key, suffix);
-        result = findTemplate(interpolatedKey, false);
+        result = findTemplate(interpolatedKey);
       }
-      return result != null ? result : result = findTemplate(key, true);
+      return result != null ? result : findTemplate(key);
     },
 
     t: function(key, context) {
       var template;
       if (context == null) context = {};
       template = I18n.template(key, get(context, 'count'));
+
+      if (template == null) {
+        template = I18n.translations[key] = function() {
+          return I18n.missingMessage(key, context);
+        };
+        template._isMissing = true;
+        I18n.trigger('missing', key);
+      }
+
       return template(context);
     },
 

--- a/spec/tSpec.js
+++ b/spec/tSpec.js
@@ -59,17 +59,27 @@ describe('Ember.I18n.t', function() {
     expect(Ember.I18n.t('nothing.here')).to.equal('Missing translation: nothing.here');
   });
 
-  it('warns with a custom message', function() {
-    Ember.I18n.missingMessage = function(key) { return "there.is." + key + ".to.see"; };
-    expect(Ember.I18n.t('nothing.here')).to.equal('there.is.nothing.here.to.see');
-  });
+  describe('missing message', function(){
+    beforeEach(function() {
+      this.oldMissingMessage = Ember.I18n.missingMessage;
+    });
 
-  it('warns with a custom message that includes the passed context', function() {
-    Ember.I18n.missingMessage = function(key, context) {
-      var values = Object.keys(context).map(function(key) { return context[key]; });
-      return key + ',' + (values.join(','));
-    };
-    expect(Ember.I18n.t('foo', { arg1: 'bar', arg2: 'qux' })).to.equal('foo,bar,qux');
+    afterEach(function() {
+      Ember.I18n.missingMessage = this.oldMissingMessage;
+    });
+
+    it('can be set to a custom message', function() {
+      Ember.I18n.missingMessage = function(key) { return "there.is." + key + ".to.see"; };
+      expect(Ember.I18n.t('nothing.here')).to.equal('there.is.nothing.here.to.see');
+    });
+
+    it('can make use of the passed context', function() {
+      Ember.I18n.missingMessage = function(key, context) {
+        var values = Object.keys(context).map(function(key) { return context[key]; });
+        return key + ',' + (values.join(','));
+      };
+      expect(Ember.I18n.t('foo', { arg1: 'bar', arg2: 'qux' })).to.equal('foo,bar,qux');
+    });
   });
 
   describe('missing event', function() {

--- a/spec/tSpec.js
+++ b/spec/tSpec.js
@@ -83,7 +83,16 @@ describe('Ember.I18n.t', function() {
       spy = sinon.spy();
       Ember.I18n.on('missing', spy);
       Ember.I18n.t('nothing.here');
-      expect(spy.calledWithExactly('nothing.here')).to.equal(true);
+      expect(spy.calledWith('nothing.here')).to.equal(true);
+    });
+
+    it('triggers missing events with the context included', function() {
+      spy = sinon.spy();
+      Ember.I18n.on('missing', spy);
+      var context = { arg1: 'bar', arg2: 'qux' };
+
+      Ember.I18n.t('nothing.here', context);
+      expect(spy.calledWithExactly('nothing.here', context)).to.equal(true);
     });
   });
 

--- a/spec/tSpec.js
+++ b/spec/tSpec.js
@@ -64,6 +64,14 @@ describe('Ember.I18n.t', function() {
     expect(Ember.I18n.t('nothing.here')).to.equal('there.is.nothing.here.to.see');
   });
 
+  it('warns with a custom message that includes the passed context', function() {
+    Ember.I18n.missingMessage = function(key, context) {
+      var values = Object.keys(context).map(function(key) { return context[key]; });
+      return key + ',' + (values.join(','));
+    };
+    expect(Ember.I18n.t('foo', { arg1: 'bar', arg2: 'qux' })).to.equal('foo,bar,qux');
+  });
+
   describe('missing event', function() {
     var spy;
 


### PR DESCRIPTION
With this change, the `Ember.I18n.missingMessage` function receives a second argument that is the context passed to the `t` function. This way, in your missing message, you can spit out the data that was supposed to be interpolated in the translation.

I moved some logic around to get access to the context – I'm pretty sure the result is equivalent, and it still passes all the tests. One question I had is whether it's intentional that `missingMessage` is not documented in the README (perhaps because 3.0 is still "beta"). If desired, I'd be happy to add this documentation.