### PR TITLE
Schedule setting up observers in afterRender queue

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -124,6 +124,10 @@
           this.addObserver(attribute + 'Translation', this, this._translationObserver);
           set(this, attribute, translation);
         });
+      },
+
+      _scheduleObservers: function() {
+        Ember.run.scheduleOnce('afterRender', this, this._addTranslationObservers);
       }.on('init'),
 
       _removeTranslationObservers: function (){

--- a/spec/translateablePropertiesSpec.js
+++ b/spec/translateablePropertiesSpec.js
@@ -1,16 +1,14 @@
 describe('TranslateableProperties', function() {
 
   it('translates ___Translation attributes on the object', function() {
-    var subject = Ember.Object.extend(Ember.I18n.TranslateableProperties).create({
-      titleTranslation: 'foo.bar'
-    });
+    var klass = Ember.Object.extend(Ember.I18n.TranslateableProperties);
+    var subject = Ember.run(klass, 'create', { titleTranslation: 'foo.bar' });
     expect(subject.get('title')).to.equal('A Foobar');
   });
 
   it('updates translations when the upstream value changes', function() {
-    var subject = Ember.Object.extend(Ember.I18n.TranslateableProperties).create({
-      titleTranslation: 'foo.bar'
-    });
+    var klass = Ember.Object.extend(Ember.I18n.TranslateableProperties);
+    var subject = Ember.run(klass, 'create', { titleTranslation: 'foo.bar' });
     expect(subject.get('title')).to.equal('A Foobar');
     subject.set('titleTranslation', 'foos.zero');
     expect(subject.get('title')).to.equal('No Foos');


### PR DESCRIPTION
https://github.com/jamesarosen/ember-i18n/issues/198

When including TranslateableProperties in ObjectControllers, setting
properties to their translations fail because the model (ie content)
isn't available. This change schedules this work in the afterRender queue so
that models are guaranteed to be set on the controller.