### PR TITLE
{{t}} composite keys

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -144,8 +144,20 @@
 
   Ember.I18n = I18n;
 
-  EmHandlebars.registerBoundHelper('t', function(key, options) {
-    return new EmHandlebars.SafeString(I18n.t(key, options.hash));
+  EmHandlebars.registerBoundHelper('t', function() {
+    var args = Array.prototype.slice.call(arguments),
+        lastArgument = args[args.length-1],
+        options = {},
+        key;
+
+    if(typeof lastArgument === 'object') {
+      options = lastArgument.hash;
+      args.pop();
+    }
+
+    key = args.join('.');
+
+    return new EmHandlebars.SafeString(I18n.t(key, options));
   });
 
 }).call(undefined);

--- a/spec/translateHelperSpec.js
+++ b/spec/translateHelperSpec.js
@@ -67,6 +67,27 @@ describe('{{t}}', function() {
       expect(view.$().text()).to.equal('All 4 Bars');
     });
   });
+
+  it('compose keys from arguments', function() {
+    var view = this.renderTemplate('{{t "foo" "bar"}}');
+
+    Ember.run(function() {
+      expect(view.$().text()).to.equal('A Foobar');
+    });
+  });
+
+  it('compose keys from arguments that bound properties', function() {
+    var view = this.renderTemplate('{{t "foo" view.prop}}');
+
+    Ember.run(function() {
+      view.rerender();
+      view.set('prop', 'bar');
+    });
+
+    Ember.run(function() {
+      expect(view.$().text()).to.equal('A Foobar');
+    });
+  });
 });
 
 describe('{{{t}}}', function() {


### PR DESCRIPTION
Simple feature that allow to build translation keys by passing multiple argument to `{{t}}` helper. Example:
`{{t "foo" "bar"}}` is equal to `{{t "foo.bar"}}`. As helper arguments can be properties on template context you can write something like this: `{{t "foo" someProperty}}`.

This change is a result of previous discussions: https://github.com/jamesarosen/ember-i18n/issues/131 https://github.com/jamesarosen/ember-i18n/pull/113 https://github.com/jamesarosen/ember-i18n/issues/41