### PR TITLE
Fix bug with "sticky" missing message context

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -92,7 +92,7 @@
       if (context == null) context = {};
       template = I18n.template(key, get(context, 'count'));
 
-      if (template == null) {
+      if (template == null || template._isMissing) {
         template = I18n.translations[key] = function() {
           return I18n.missingMessage(key, context);
         };

--- a/spec/tSpec.js
+++ b/spec/tSpec.js
@@ -73,12 +73,22 @@ describe('Ember.I18n.t', function() {
       expect(Ember.I18n.t('nothing.here')).to.equal('there.is.nothing.here.to.see');
     });
 
-    it('can make use of the passed context', function() {
-      Ember.I18n.missingMessage = function(key, context) {
-        var values = Object.keys(context).map(function(key) { return context[key]; });
-        return key + ',' + (values.join(','));
-      };
-      expect(Ember.I18n.t('foo', { arg1: 'bar', arg2: 'qux' })).to.equal('foo,bar,qux');
+    describe('translation context', function() {
+      beforeEach(function() {
+        Ember.I18n.missingMessage = function(key, context) {
+          var values = Object.keys(context).map(function(key) { return context[key]; });
+          return key + ':' + (values.join(','));
+        };
+      });
+
+      it('is passed to the function', function() {
+        expect(Ember.I18n.t('foo', { arg1: 'bar', arg2: 'qux' })).to.equal('foo:bar,qux');
+      });
+
+      it('is passed with new values when the translation is called again', function() {
+        Ember.I18n.t('foo', { arg1: 'bar', arg2: 'qux' });
+        expect(Ember.I18n.t('foo', { arg1: 'qux', arg2: 'baz' })).to.equal('foo:qux,baz');
+      });
     });
   });
 


### PR DESCRIPTION
Fixing a bug that I introduced while adding the "missing message context" feature. The first time `t` was called with a missing key, it would mistakenly cache the context of that call and pass it to all subsequent `missingMessage` calls, even when `t` was later called with the same key but a different context.

This has minor performance implications, since the "missing function" for a given key is now regenerated every time `t` is called with that key. I couldn't immediately think of a better way to fix the problem, and hopefully no one is relying too much on the performance of the missing-translation handler anyway.