### PR TITLE
Do not assume there's prototype extension

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -126,18 +126,18 @@
         });
       },
 
-      _scheduleObservers: function() {
+      _scheduleObservers: Ember.on('init', function() {
         Ember.run.scheduleOnce('render', this, this._addTranslationObservers);
-      }.on('init'),
+      }),
 
-      _removeTranslationObservers: function (){
+      _removeTranslationObservers: Ember.on('willDestroyElement','willClearRender', function() {
         eachTranslatedAttribute(this, function(attribute) {
           var propWithSuffix = attribute + 'Translation';
           if(this.hasObserverFor(propWithSuffix)) {
             this.removeObserver(propWithSuffix, this._translationObserver);
           }
         });
-      }.on('willDestroyElement','willClearRender')
+      })
     }),
 
     TranslateableAttributes: Ember.Mixin.create({


### PR DESCRIPTION
With EmberCLI 0.2.2+ [ember-disable-prototype-extensions is included by default](http://www.ember-cli.com/#section-1), so we cannot assume them to be there anymore.