### PR TITLE
Add translation observers in render queue

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -127,7 +127,7 @@
       },
 
       _scheduleObservers: function() {
-        Ember.run.scheduleOnce('afterRender', this, this._addTranslationObservers);
+        Ember.run.scheduleOnce('render', this, this._addTranslationObservers);
       }.on('init'),
 
       _removeTranslationObservers: function (){


### PR DESCRIPTION
My use case centers on passing a translateable
property to a component, such as the prompt for a select dropdown.
Putting this work in the `afterRender` queue will not cause the
translations to be loaded before rendering. Hence, this work belongs in
the `render` queue.