### PR TITLE
Have observers set on init, component/views properties are dependent on translateable properties

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -127,7 +127,7 @@
       },
 
       _scheduleObservers: function() {
-        Ember.run.scheduleOnce('afterRender', this, this._addTranslationObservers);
+        this._addTranslationObservers();
       }.on('init'),
 
       _removeTranslationObservers: function (){


### PR DESCRIPTION
I noticed that when having observers set in `afterRender` queue, properties dependent on translatable properties reference an undefined translatable property since the translatable properties are not loaded until after render.

^no idea if that makes sense, queue xzbit meme