### PR TITLE
i18n must go through Ember.get since Ember.inject.service is lazy

### DIFF
--- a/addon/macro.js
+++ b/addon/macro.js
@@ -7,8 +7,9 @@ const get = Ember.get;
 // @public
 export default function createTranslatedComputedProperty(key, interpolations) {
   return Ember.computed(values(interpolations), function() {
-    Ember.assert(`Cannot translate ${key}. ${this} does not have an i18n.`, this.i18n);
-    return this.i18n.t(key, mapPropertiesByHash(this, interpolations));
+    var i18n = this.get('i18n');
+    Ember.assert(`Cannot translate ${key}. ${this} does not have an i18n.`, i18n);
+    return i18n.t(key, mapPropertiesByHash(this, interpolations));
   });
 }
 


### PR DESCRIPTION
`this.i18n` must go through Ember.get since `Ember.inject.service` is lazy.  Could be an issue for those that inject the service with `i18n: Ember.inject.service()` since you've documented it here:
https://github.com/jamesarosen/ember-i18n/commit/12e56e755ac376d4e716dee1931cbc68bfac0661#diff-04c6e90faac2675aa89e2176d2eec7d8R85