### PR TITLE
t macro works with no interpolations map

### DIFF
--- a/addon/macro.js
+++ b/addon/macro.js
@@ -5,9 +5,9 @@ const keys = Ember.keys;
 const get = Ember.get;
 
 // @public
-export default function createTranslatedComputedProperty(key, interpolations) {
+export default function createTranslatedComputedProperty(key, interpolations = {}) {
   return Ember.computed(values(interpolations), function() {
-    var i18n = this.get('i18n');
+    const i18n = get(this, 'i18n');
     Ember.assert(`Cannot translate ${key}. ${this} does not have an i18n.`, i18n);
     return i18n.t(key, mapPropertiesByHash(this, interpolations));
   });

--- a/tests/unit/macro-test.js
+++ b/tests/unit/macro-test.js
@@ -13,16 +13,22 @@ moduleFor('service:i18n', 'translationMacro', {
 
       numberClicks: 9,
 
-      tMacroProperty: t('with.interpolations', { clicks: 'numberClicks' }),
+      tMacroProperty1: t('no.interpolations'),
+
+      tMacroProperty2: t('with.interpolations', { clicks: 'numberClicks' }),
     }).create();
   }
 });
 
-test('defines a computed property that translates', function(assert) {
-  assert.equal(this.object.get('tMacroProperty'), 'Clicks: 9');
+test('defines a computed property that translates without interpolations', function(assert) {
+  assert.equal(this.object.get('tMacroProperty1'), 'text with no interpolations');
+});
+
+test('defines a computed property that translates with interpolations', function(assert) {
+  assert.equal(this.object.get('tMacroProperty2'), 'Clicks: 9');
 });
 
 test('defines a computed property with dependencies', function(assert) {
   Ember.run(this.object, 'set', 'numberClicks', 13);
-  assert.equal(this.object.get('tMacroProperty'), 'Clicks: 13');
+  assert.equal(this.object.get('tMacroProperty2'), 'Clicks: 13');
 });


### PR DESCRIPTION
While we're here, change `var` to `const` and `this.get('i18n')` to `get(this, 'i18n')` for improved safety and consistency.

Fixes #221