### PR TITLE
Explain that you can't translate until `ember-i18n` initializer runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ export default {
   name: 'my-initializer',
   after: 'ember-i18n',
   initialize: function({ container }) {
-    let i18n = container.lookup('service:i18n');
-    i18n.t('some.translation');
+    const i18n = container.lookup('service:i18n');
+    document.title = i18n.t('some.translation');
   }
 };
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ injected into every Route, Controller and Component in your app. If you need it
 elsewhere, you can register your own injection:
 
 ```js
-// app/initializers/i18n.js
+// app/instance-initializers/i18n.js
 
 export default {
   name: 'i18n',
@@ -91,6 +91,21 @@ export default Ember.Object.extend({
   i18n: Ember.inject.service()
 });
 ```
+
+If you want to use i18n from within an initializer you need to make sure that it runs after the
+`ember-i18n` initializer has been executed.
+
+```js
+// app/instance-initializers/my-initializer.js
+
+export default {
+  name: 'my-initializer',
+  after: 'ember-i18n',
+  initialize: function({ container }) {
+    let i18n = container.lookup('service:i18n');
+    i18n.t('some.translation');
+  }
+};
 
 #### Adding Translations at Runtime
 


### PR DESCRIPTION
This bite me yesterday. 

Since the order of the initializers is not enforced, some could do translations and other couldn't because the locale was not defined yet. 

