### PR TITLE
[BUG] Dynamic keys are not being translated

### DIFF
--- a/tests/acceptance/t-helper-test.js
+++ b/tests/acceptance/t-helper-test.js
@@ -23,6 +23,18 @@ test('renders with static interpolations', function(assert) {
   assert.textIs('.static-interpolations', 'Clicks: 45');
 });
 
+test('renders translations of dynamic keys', function(assert) {
+  assert.textIs('.dynamic-key', 'text with no interpolations');
+});
+
+test('updates translations of dynamic keys', function(assert) {
+  assert.textIs('.dynamic-key', 'text with no interpolations');
+
+  click('.change-dynamic-key');
+
+  assert.textIs('.dynamic-key', 'another text without interpolations');
+});
+
 test('updates when dynamic interpolations change', function(assert) {
   assert.textIs('.dynamic-interpolations', 'Clicks: 0');
 

--- a/tests/dummy/app/controllers/translate.js
+++ b/tests/dummy/app/controllers/translate.js
@@ -8,6 +8,10 @@ export default Ember.Controller.extend({
   actions: {
     increment: function() {
       this.incrementProperty('clickCount');
+    },
+
+    changeDynamicKey(newKey) {
+      this.set('dynamicKey', newKey);
     }
   }
 

--- a/tests/dummy/app/locales/en/translations.js
+++ b/tests/dummy/app/locales/en/translations.js
@@ -1,5 +1,6 @@
 export default {
   'no.interpolations': 'text with no interpolations',
+  'no.interpolations.either': 'another text without interpolations',
 
   'with': {
     interpolations: 'Clicks: {{clicks}}'

--- a/tests/dummy/app/routes/translate.js
+++ b/tests/dummy/app/routes/translate.js
@@ -10,6 +10,7 @@ export default Ember.Route.extend({
 
   afterModel: function(locale) {
     this.set('i18n.locale', locale);
+    this.set('dynamicKey', 'no.interpolations');
   }
 
 });

--- a/tests/dummy/app/templates/translate.hbs
+++ b/tests/dummy/app/templates/translate.hbs
@@ -11,3 +11,9 @@
 
   <span class='dynamic-interpolations'>{{t "with.interpolations" clicks=clickCount}}</span>
 </section>
+
+<section>
+  <button class='change-dynamic-key' {{action "changeDynamicKey" "no.interpolations.either"}}>Increment Click Count</button>
+
+  <span class='dynamic-key'>{{t dynamicKey}}</span>
+</section>


### PR DESCRIPTION
Things like `{{t dynamicKey}}` are not working ATM. This PR includes a
failing test.

The {{t}} helper (signature t(params, hash, options, env)) is receiving
a an array if `Stream` objects in `params`, not the actual values coming
from that stream.

I suspect (because I saw this in the past) that is because of the way
the helper is being registered. The registration of helpers has changed
a few times since HTMLBars.