### PR TITLE
support podModulePrefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=default POD_MODULE_PREFIX="dummy/pods"
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/addon/add-translations.js
+++ b/addon/add-translations.js
@@ -1,7 +1,7 @@
 import Ember from "ember";
 
 export default function addTranslations(locale, newTranslations, container) {
-  const key = `translations:locales/${locale}`;
+  const key = `locale:${locale}/translations`;
   var existingTranslations = container.lookupFactory(key);
 
   if (existingTranslations == null) {

--- a/addon/locale.js
+++ b/addon/locale.js
@@ -86,7 +86,7 @@ function getFlattenedTranslations(id, container) {
     Ember.merge(result, getFlattenedTranslations(parentId, container));
   }
 
-  const translations = container.lookupFactory(`translations:locales/${id}`) || {};
+  const translations = container.lookupFactory(`locale:${id}/translations`) || {};
   Ember.merge(result, withFlattenedKeys(translations));
 
   return result;
@@ -94,7 +94,7 @@ function getFlattenedTranslations(id, container) {
 
 // Walk up confiugration objects from most specific to least.
 function walkConfigs(id, container, fn) {
-  const appConfig = container.lookupFactory(`config:locales/${id}`);
+  const appConfig = container.lookupFactory(`locale:${id}/config`);
   if (appConfig) { fn(appConfig); }
 
   const addonConfig = container.lookupFactory(`ember-i18n@config:${id}`);

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -3,6 +3,7 @@
 module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
+    podModulePrefix: process.env.POD_MODULE_PREFIX,
     environment: environment,
     baseURL: '/',
     i18n: { defaultLocale: 'en' },


### PR DESCRIPTION
Previously, we were looking up `translations:locales/en`. That works with `podModulePrefix` unset, but breaks with it set. Instead, we turn the lookup string around: `locale:en/translations`.

This adds an additional test run with `podModulePrefix` set to `dummy/pods`.

Resolves #241