### PR TITLE
Swap injection info to initializer in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ export default Ember.Object.extend({
 If you find yourself needing it in many places, you can declare an injection:
 
 ```js
-// app/instance-initializers/i18n.js
+// app/initializers/i18n.js
 
 export default {
   name: 'i18n',
 
   after: 'ember-i18n',
 
-  initialize: function(app) {
+  initialize: function(_, app) {
     app.inject('model', 'i18n', 'service:i18n')
   }
 };


### PR DESCRIPTION
My simple rule of thumb for when to use an initializer vs an instance initializer is: 

* when I need to setup things for lookup at a later time, use an initializer
* when I need to look something up and perform operations on it, use an instance initializer

*tldr;* All factories and injection rules should be done before instance initializers are ran (so that they can look things up properly).