### PR TITLE
[Feature] add locales CP to the service

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,8 @@
   "predef": [
     "document",
     "window",
-    "-Promise"
+    "-Promise",
+    "requirejs"
   ],
   "browser": true,
   "boss": true,

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ this.get('i18n').addTranslations('en', {
 });
 ```
 
+#### Listing the Locales
+
+Get a list of available locales:
+
+```js
+var locales = this.get('i18n.locales');
+```
+
 #### Setting the Locale
 
 Set the default locale in `config/environment.js`:

--- a/addon/get-locales.js
+++ b/addon/get-locales.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+const matchKey = '/locales/(.+)/translations$';
+
+export default function getLocales() {
+  return Ember.keys(requirejs.entries).reduce((locales, module) => {
+    var match = module.match(matchKey);
+    if (match) {
+      locales.pushObject(match[1]);
+    }
+    return locales;
+  }, Ember.A());
+}

--- a/addon/service.js
+++ b/addon/service.js
@@ -2,6 +2,7 @@ import Ember from "ember";
 import Stream from "./stream";
 import Locale from "./locale";
 import addTranslations from "./add-translations";
+import getLocales from "./get-locales";
 
 const get = Ember.get;
 const Parent = Ember.Service || Ember.Object;
@@ -12,6 +13,10 @@ export default Parent.extend(Ember.Evented, {
   // @public
   // The user's locale.
   locale: null,
+
+  // @public
+  // A list of found locales.
+  locales: Ember.computed(getLocales),
 
   // @public
   //

--- a/tests/unit/locales-test.js
+++ b/tests/unit/locales-test.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:i18n', 'I18nService#locales', {
+  integration: true
+});
+
+const locales = [
+  'en-bw',
+  'en-ps',
+  'en-wz',
+  'en',
+  'es'
+];
+
+test('locales have the correct length and names', function(assert) {
+  const i18n = this.subject();
+
+  assert.deepEqual(i18n.get('locales'), locales);
+});


### PR DESCRIPTION
A result of #247. Adds a way to get a list of the added locales. Useful for rendering this list to a template to switch locales.