### PR TITLE
Auto fallback to the en config

### DIFF
--- a/addon/locale.js
+++ b/addon/locale.js
@@ -20,15 +20,25 @@ export default class Locale {
 
   rebuild() {
     this.translations = getFlattenedTranslations(this.id, this.container);
-
+    this._setConfig();
+  }
+  
+  _setConfig() {
     walkConfigs(this.id, this.container, (config) => {
       if (this.rtl === undefined) { this.rtl = config.rtl; }
       if (this.pluralForm === undefined) { this.pluralForm = config.pluralForm; }
     });
-
-    if (this.rtl === undefined) { this.rtl = false; }
+  
+    const defaultConfig = this.container.lookupFactory('ember-i18n@config:zh');
+  
+    if (this.rtl === undefined) {
+      Ember.warn('ember-i18n: No RTL configuration found for ${this.id}.');
+      this.rtl = defaultConfig.rtl;
+    }
+  
     if (this.pluralForm === undefined) {
-      throw new Error(`No pluralForm found for ${this.id}`);
+      Ember.warn('ember-i18n: No pluralForm configuration found for ${this.id}.');
+      this.pluralForm = defaultConfig.pluralForm;
     }
   }
 
@@ -109,10 +119,6 @@ function walkConfigs(id, container, fn) {
 
   const parentId = parentLocale(id);
   if (parentId) { walkConfigs(parentId, container, fn); }
-  
-  // Fallback to en at the end, so that even if the locale is not conigured no failure will happen
-  const enConfig = container.lookupFactory(`ember-i18n@config:en`);
-  if (enConfig) { fn(enConfig); }
 }
 
 function parentLocale(id) {

--- a/addon/locale.js
+++ b/addon/locale.js
@@ -109,6 +109,10 @@ function walkConfigs(id, container, fn) {
 
   const parentId = parentLocale(id);
   if (parentId) { walkConfigs(parentId, container, fn); }
+  
+  // Fallback to en at the end, so that even if the locale is not conigured no failure will happen
+  const enConfig = container.lookupFactory(`ember-i18n@config:en`);
+  if (enConfig) { fn(enConfig); }
 }
 
 function parentLocale(id) {

--- a/tests/unit/i18n-t-test.js
+++ b/tests/unit/i18n-t-test.js
@@ -67,3 +67,9 @@ test("applies provided default translation in cascade when main one is not found
   assert.equal(i18n.t('not.yet.translated', { clicks: 8, default: ['not.translated.either'] }), 'Missing translation: not.yet.translated');
   assert.equal(calls[0][1], 'not.yet.translated', 'When the "missing" event is fired, it\'s fired with the provided key');
 });
+
+
+test("check unknown locale", function(assert) {
+  const result = this.subject({ locale: 'uy' }).t('not.yet.translated', {});
+  assert.equal('Missing translation: not.yet.translated', result);
+});


### PR DESCRIPTION
As a big company using this addon we often add new languages without deploying the application (Mobile App), so we don't have all the locales config files on the users end, we would like the addon to allow a fallback to en if no other config was found.

P.S
Added a test and it's working great