### PR TITLE
Replaced calls to the deprecated Ember.keys function with Object.keys

### DIFF
--- a/addon/get-locales.js
+++ b/addon/get-locales.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 const matchKey = '/locales/(.+)/translations$';
 
 export default function getLocales() {
-  return Ember.keys(requirejs.entries).reduce((locales, module) => {
+  return Object.keys(requirejs.entries).reduce((locales, module) => {
     var match = module.match(matchKey);
     if (match) {
       locales.pushObject(match[1]);

--- a/addon/legacy-helper.js
+++ b/addon/legacy-helper.js
@@ -21,7 +21,7 @@ if (Ember.Helper == null) {
     });
 
     // observe any hash arguments that are streams:
-    Ember.keys(hash).forEach(function(key) {
+    Object.keys(hash).forEach(function(key) {
       const value = hash[key];
 
       if (value && value.isStream) {

--- a/addon/locale.js
+++ b/addon/locale.js
@@ -129,13 +129,13 @@ function parentLocale(id) {
 function withFlattenedKeys(object) {
   const result = {};
 
-  Ember.keys(object).forEach(function(key) {
+  Object.keys(object).forEach(function(key) {
     var value = object[key];
 
     if (Ember.typeOf(value) === 'object') {
       value = withFlattenedKeys(value);
 
-      Ember.keys(value).forEach(function(suffix) {
+      Object.keys(value).forEach(function(suffix) {
         result[`${key}.${suffix}`] = value[suffix];
       });
     } else {

--- a/addon/macro.js
+++ b/addon/macro.js
@@ -1,6 +1,6 @@
 import Ember from "ember";
 
-const keys = Ember.keys;
+const keys = Object.keys;
 const get = Ember.get;
 
 // @public


### PR DESCRIPTION
Using `Ember.keys` is deprecated, see https://github.com/emberjs/ember.js/commit/1ed73ac3d1c218b9a3b56640543fd13d0913d27e.