### PR TITLE
Improve config-missing warnings

### DIFF
--- a/addon/config/en.js
+++ b/addon/config/en.js
@@ -1,6 +1,8 @@
 import { ONE, OTHER } from "./constants";
 
 export default {
+  rtl: false,
+
   pluralForm: function(n) {
     if (n === 1) { return ONE; }
     return OTHER;

--- a/addon/config/fr.js
+++ b/addon/config/fr.js
@@ -1,6 +1,8 @@
 import { ONE, OTHER } from "./constants";
 
 export default {
+  rtl: false,
+
   pluralForm: function(n) {
     if (n >= 0 && n < 2) { return ONE; }
     return OTHER;

--- a/addon/config/hi.js
+++ b/addon/config/hi.js
@@ -1,6 +1,8 @@
 import { ONE, OTHER } from "./constants";
 
 export default {
+  rtl: false,
+
   pluralForm: function(n) {
     if (n === 0) { return ONE; }
     if (n === 1) { return ONE; }

--- a/addon/config/ru.js
+++ b/addon/config/ru.js
@@ -1,6 +1,8 @@
 import { ONE, FEW, MANY, OTHER } from './constants';
 
 export default {
+  rtl: false,
+
   pluralForm: function(n) {
     const mod1 = n % 1;
     const mod10 = n % 10;

--- a/addon/config/zh.js
+++ b/addon/config/zh.js
@@ -1,6 +1,8 @@
 import { OTHER } from './constants';
 
 export default {
+  rtl: false,
+
   pluralForm: function(/* n */) {
     return OTHER;
   }

--- a/addon/locale.js
+++ b/addon/locale.js
@@ -32,12 +32,12 @@ export default class Locale {
     const defaultConfig = this.container.lookupFactory('ember-i18n@config:zh');
 
     if (this.rtl === undefined) {
-      Ember.warn('ember-i18n: No RTL configuration found for ${this.id}.');
+      Ember.warn(`ember-i18n: No RTL configuration found for ${this.id}.`);
       this.rtl = defaultConfig.rtl;
     }
 
     if (this.pluralForm === undefined) {
-      Ember.warn('ember-i18n: No pluralForm configuration found for ${this.id}.');
+      Ember.warn(`ember-i18n: No pluralForm configuration found for ${this.id}.`);
       this.pluralForm = defaultConfig.pluralForm;
     }
   }


### PR DESCRIPTION
The new `Locale#_setConfig` introduced in #263 relies on *some* config in the path defining `rtl`. If it's `undefined`, `_setConfig` now emits a warning. Previously, we were relying on `undefined` being falsy, but we need to specify a value (`false`) to prevent the warning. We define `rtl: false` for en, fr, hi, ru, and zh. All other included locales either define `rtl: true` or inherit from one of these.

Additionally, the warnings added in #263 used ES6 string interpolation, but didn't have the correct ES6 string syntax. This corrects that, which makes for better error messages.

    