### PR TITLE
add test helpers

### DIFF
--- a/test-support/helpers/ember-i18n/test-helpers.js
+++ b/test-support/helpers/ember-i18n/test-helpers.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+
+// example usage: find(`.header:contains(${t('welcome_message')})`)
+Ember.Test.registerHelper('t', function(app, key, interpolations){
+  const i18n = app.__container__.lookup('service:i18n');
+  return i18n.t(key, interpolations);
+});
+
+// example usage: expectTranslation('.header', 'welcome_message');
+Ember.Test.registerHelper('expectTranslation', function(app, element, key, interpolations){
+  const text = app.testHelpers.t(key, interpolations);
+
+  assertTranslation(element, key, text);
+});
+
+const assertTranslation = (function() {
+  if (typeof QUnit !== 'undefined' && typeof ok === 'function') {
+    return function(element, key, text) {
+      ok(find(`${element}:contains(${text})`).length, `Found translation key ${key} in ${element}`);
+    };
+  } else if (typeof expect === 'function') {
+    return function(element, key, text) {
+      const found = !!(find(`${element}:contains(${text})`).length);
+      expect(found).to.equal(true);
+    };
+  } else {
+    return function() {
+      throw new Error("ember-i18n could not find a compatible test framework");
+    };
+  }
+}());

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -22,7 +22,9 @@
     "andThen",
     "currentURL",
     "currentPath",
-    "currentRouteName"
+    "currentRouteName",
+    "t",
+    "expectTranslation"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/test-helpers-test.js
+++ b/tests/acceptance/test-helpers-test.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+
+var app;
+
+module('Acceptance: {{t}} Helper', {
+  beforeEach: function() {
+    app = startApp();
+    visit('/');
+  },
+
+  afterEach: function() {
+    Ember.run(app, 'destroy');
+  }
+});
+
+test("t test helper", function(assert) {
+  assert.equal(t("pluralized.translation", { count: 1 }), "One Click", "test-helpers t returns translation");
+});
+
+test("expectTranslation test helper", function(assert) {
+  expectTranslation('.no-interpolations', 'no.interpolations');
+});

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import Application from '../../app';
 import Router from '../../router';
 import config from '../../config/environment';
+import './ember-i18n/test-helpers';
 
 export default function startApp(attrs) {
   var application;


### PR DESCRIPTION
@jamesarosen Adds some test helpers that can be imported into any app that uses the add-on.

To use in an app,  in `tests/helpers/start-app.js` add this line: 

`import './ember-i18n/test-helpers';`

You can use the `t` helper like this:  ``find(`.header:contains(${t('welcome_message')})`)``

and the `expectTranslation` helper like this: `expectTranslation('.header', 'welcome_message');`

[blog post](http://williamsbdev.com/posts/Ember-CLI-test-support/) about including test helpers in the `test-support` directory.

After this is merged I'll add some documentation to the wiki.
