### PR TITLE
Allow overriding the locale for individual translations

### DIFF
--- a/tests/acceptance/t-helper-test.js
+++ b/tests/acceptance/t-helper-test.js
@@ -50,3 +50,7 @@ test('updates when the locale changes', function(assert) {
     assert.textIs('.no-interpolations', 'texto sin interpolaciones');
   });
 });
+
+test('can override the target locale', function(assert) {
+  assert.textIs('.locale-override', 'texto sin interpolaciones');
+});

--- a/tests/dummy/app/locales/en/translations.js
+++ b/tests/dummy/app/locales/en/translations.js
@@ -3,7 +3,8 @@ export default {
   'no.interpolations.either': 'another text without interpolations',
 
   'with': {
-    interpolations: 'Clicks: {{clicks}}'
+    interpolations: 'Clicks: {{clicks}}',
+    'locale.interpolation': 'Locale: {{locale}}'
   },
 
   'pluralized.translation': {

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -21,3 +21,7 @@
 <section>
   <button class='switch-to-es' {{action "switchLocale" "es"}}>Switch to Spanish</button>
 </section>
+
+<section>
+  <span class='locale-override'>{{t "no.interpolations" locale="es"}}</span>
+</section>

--- a/tests/unit/i18n-exists-test.js
+++ b/tests/unit/i18n-exists-test.js
@@ -41,3 +41,9 @@ test('non-existing translations when checked twice do not exist', function (asse
   assert.equal(i18n.t('not.existing'), 'Missing translation: not.existing');
   assert.equal(i18n.exists('not.existing'), false);
 });
+
+test('allows overriding the locale', function(assert) {
+  const i18n = this.subject({ locale: 'en' });
+
+  assert.equal(i18n.exists('no.interpolations.either', { locale: 'es' }), false);
+});


### PR DESCRIPTION
I had some free time, so here is my initial stab at #298. I couldn't find a way to stub the ENV value so I could test that it's correctly loaded into the service, but I manually confirmed that it works.
