### PR TITLE
Init Locale in Service

### DIFF
--- a/addon/services/i18n.js
+++ b/addon/services/i18n.js
@@ -4,7 +4,7 @@ import Locale from "../utils/locale";
 import addTranslations from "../utils/add-translations";
 import getLocales from "../utils/get-locales";
 
-const { get, makeArray, computed } = Ember;
+const { get, makeArray, computed, on, warn } = Ember;
 const Parent = Ember.Service || Ember.Object;
 
 // @public
@@ -60,7 +60,21 @@ export default Parent.extend(Ember.Evented, {
   },
 
   // @private
-  // 
+  _initDefaults: on('init', function() {
+    const ENV = this.container.lookupFactory('config:environment');
+
+    if (this.get('locale') == null) {
+      var defaultLocale = (ENV.i18n || {}).defaultLocale;
+      if (defaultLocale == null) {
+        warn('ember-i18n did not find a default locale; falling back to "en".');
+        defaultLocale = 'en';
+      }
+      this.set('locale', defaultLocale);
+    }
+  }),
+
+  // @private
+  //
   // adds a runtime locale to the array of locales on disk
   _addLocale(locale) {
     this.get('locales').addObject(locale);
@@ -71,7 +85,7 @@ export default Parent.extend(Ember.Evented, {
     return locale ? new Locale(this.get('locale'), this.container) : null;
   }),
 
-  _buildLocaleStream: Ember.on('init', function() {
+  _buildLocaleStream: on('init', function() {
     this.localeStream = new Stream(() => {
       return this.get('locale');
     });

--- a/addon/services/i18n.js
+++ b/addon/services/i18n.js
@@ -4,11 +4,11 @@ import Locale from "../utils/locale";
 import addTranslations from "../utils/add-translations";
 import getLocales from "../utils/get-locales";
 
-const { get, makeArray, computed, on, warn } = Ember;
+const { assert, computed, get, Evented, makeArray, observer, on, typeOf, warn } = Ember;
 const Parent = Ember.Service || Ember.Object;
 
 // @public
-export default Parent.extend(Ember.Evented, {
+export default Parent.extend(Evented, {
 
   // @public
   // The user's locale.
@@ -24,7 +24,7 @@ export default Parent.extend(Ember.Evented, {
   // in the current `locale`.
   t: function(key, data = {}) {
     const locale = this.get('_locale');
-    Ember.assert("I18n: Cannot translate when locale is null", locale);
+    assert("I18n: Cannot translate when locale is null", locale);
     const count = get(data, 'count');
 
     const defaults = makeArray(get(data, 'default'));
@@ -42,11 +42,11 @@ export default Parent.extend(Ember.Evented, {
   // @public
   exists: function(key, data = {}) {
     const locale = this.get('_locale');
-    Ember.assert("I18n: Cannot check existance when locale is null", locale);
+    assert("I18n: Cannot check existance when locale is null", locale);
     const count = get(data, 'count');
 
     const translation = locale.findTranslation(makeArray(key), count);
-    return Ember.typeOf(translation.result) !== 'undefined';
+    return typeOf(translation.result) !== 'undefined';
   },
 
   // @public
@@ -80,7 +80,7 @@ export default Parent.extend(Ember.Evented, {
     this.get('locales').addObject(locale);
   },
 
-  _locale: Ember.computed('locale', function() {
+  _locale: computed('locale', function() {
     const locale = this.get('locale');
     return locale ? new Locale(this.get('locale'), this.container) : null;
   }),
@@ -91,7 +91,7 @@ export default Parent.extend(Ember.Evented, {
     });
   }),
 
-  _notifyLocaleStream: Ember.observer('locale', function() {
+  _notifyLocaleStream: observer('locale', function() {
     this.localeStream.value(); // force the stream to be dirty
     this.localeStream.notify();
   })

--- a/app/instance-initializers/ember-i18n.js
+++ b/app/instance-initializers/ember-i18n.js
@@ -6,15 +6,6 @@ export default {
   name: 'ember-i18n',
 
   initialize: function(instance) {
-    var defaultLocale = (ENV.i18n || {}).defaultLocale;
-    if (defaultLocale === undefined) {
-      Ember.warn('ember-i18n did not find a default locale; falling back to "en".');
-      defaultLocale = 'en';
-    }
-    const key = 'service:i18n';
-    const i18n = instance.lookup ? instance.lookup(key) : instance.container.lookup(key);
-    i18n.set('locale', defaultLocale);
-
     if (legacyHelper != null) {
       Ember.HTMLBars._registerHelper('t', legacyHelper);
     }

--- a/tests/unit/i18n-t-test.js
+++ b/tests/unit/i18n-t-test.js
@@ -7,7 +7,7 @@ moduleFor('service:i18n', 'I18nService#t', {
 test('falls back to parent locale', function(assert) {
   const i18n = this.subject({ locale: 'en-ps' });
 
-  assert.equal(i18n.t('no.interpolations'), 'téxt wîth nö ìntérpølåtíôns');
+  assert.equal('' + i18n.t('no.interpolations'), 'téxt wîth nö ìntérpølåtíôns');
   assert.equal(i18n.t('with.interpolations', { clicks: 8 }), 'Clicks: 8');
 });
 


### PR DESCRIPTION
Set default locale on Service init, not in an initializer

`on('init')` runs whenever you construct an instance, not just when the app boots. That makes the service *slightly* more usable in things like unit tests.