### PR TITLE
t macro properties observe locale

### DIFF
--- a/addon/stream.js
+++ b/addon/stream.js
@@ -2,10 +2,13 @@ import Ember from 'ember';
 
 // As of v1.12, Streams are still private API. Thus, we need to reach in to
 // Ember internals to get access to it.
+// After v2.1, the streams/stream module moved what was `Stream` to a named export and exported
+// a base class as `default`.
 //
 // See https://github.com/emberjs/ember.js/blob/v1.12.0/packages/ember-metal/lib/main.js#L384-L386
 // See https://github.com/emberjs/ember.js/pull/9693
 // See https://github.com/dockyard/ember-cli-i18n/blob/v0.0.6/addon/utils/stream.js
-
-export default Ember.__loader.require('ember-metal/streams/stream')['default'];
+// See https://github.com/emberjs/ember.js/blob/23258c1eadce4f52c814f0441c13880ddf896f31/packages/ember-metal/lib/streams/stream.js
+const streamModule = Ember.__loader.require('ember-metal/streams/stream');
+export default (streamModule.Stream || streamModule['default']);
 export var readHash = Ember.__loader.require('ember-metal/streams/utils').readHash;

--- a/addon/utils/get-locales.js
+++ b/addon/utils/get-locales.js
@@ -3,11 +3,13 @@ import Ember from 'ember';
 const matchKey = '/locales/(.+)/translations$';
 
 export default function getLocales() {
-  return Object.keys(requirejs.entries).reduce((locales, module) => {
-    var match = module.match(matchKey);
-    if (match) {
-      locales.pushObject(match[1]);
-    }
-    return locales;
-  }, Ember.A());
+  return Object.keys(requirejs.entries)
+    .reduce((locales, module) => {
+      var match = module.match(matchKey);
+      if (match) {
+        locales.pushObject(match[1]);
+      }
+      return locales;
+    }, Ember.A())
+    .sort();
 }

--- a/addon/utils/macro.js
+++ b/addon/utils/macro.js
@@ -5,7 +5,9 @@ const get = Ember.get;
 
 // @public
 export default function createTranslatedComputedProperty(key, interpolations = {}) {
-  return Ember.computed(values(interpolations), function() {
+  const dependencies = [ 'i18n.locale' ].concat(values(interpolations));
+
+  return Ember.computed(...dependencies, function() {
     const i18n = get(this, 'i18n');
     Ember.assert(`Cannot translate ${key}. ${this} does not have an i18n.`, i18n);
     return i18n.t(key, mapPropertiesByHash(this, interpolations));

--- a/tests/unit/utils/locale-test.js
+++ b/tests/unit/utils/locale-test.js
@@ -5,50 +5,49 @@ moduleFor('service:i18n', 'I18nService#locales', {
 });
 
 test('locales have the correct length and names', function(assert) {
-  const locales = [
+  const expected = [
+    'en',
     'en-bw',
     'en-ps',
     'en-wz',
-    'en',
     'es'
   ];
+  const actual = this.subject().get('locales');
 
-  const i18n = this.subject();
-
-  assert.deepEqual(i18n.get('locales'), locales);
+  assert.deepEqual(actual, expected, JSON.stringify(actual));
 });
 
 test('addTranslations adds to locales', function(assert) {
-  const locales = [
+  const expected = [
+    'en',
     'en-bw',
     'en-ps',
     'en-wz',
-    'en',
     'es',
     'it'
   ];
 
   const i18n = this.subject({ locale: 'en' });
-
   i18n.addTranslations('it', {});
+  const actual = i18n.get('locales');
 
-  assert.deepEqual(i18n.get('locales'), locales);
+  assert.deepEqual(actual, expected, JSON.stringify(actual));
 });
 
 test('addTranslations doesn\'t add duplicate locales', function(assert) {
-  const locales = [
+  const expected = [
+    'en',
     'en-bw',
     'en-ps',
     'en-wz',
-    'en',
     'es',
     'it'
   ];
 
   const i18n = this.subject({ locale: 'en' });
-
   i18n.addTranslations('it', {});
   i18n.addTranslations('it', {});
+  const actual = i18n.get('locales');
 
-  assert.deepEqual(i18n.get('locales'), locales);
+  assert.deepEqual(actual, expected, JSON.stringify(actual));
 });

--- a/tests/unit/utils/macro-test.js
+++ b/tests/unit/utils/macro-test.js
@@ -32,3 +32,9 @@ test('defines a computed property with dependencies', function(assert) {
   Ember.run(this.object, 'set', 'numberClicks', 13);
   assert.equal(this.object.get('tMacroProperty2'), 'Clicks: 13');
 });
+
+test('defines a computed property that depends on the locale', function(assert) {
+  assert.equal(this.object.get('tMacroProperty1'), 'text with no interpolations');
+  Ember.run(this.object, 'set', 'i18n.locale', 'es');
+  assert.equal(this.object.get('tMacroProperty1'), 'texto sin interpolaciones');
+});


### PR DESCRIPTION
 * Fix `locales` test intermittent failures by sorting the locales
 * Fix ember-i18n on Ember 2.2 beta by reworking the private `Stream` import
 * Add `i18n.locale` to the list of dependencies for properties defined via the `t` macro.