### PR TITLE
Streams: Ember changed a private API after v2.1

### DIFF
--- a/addon/stream.js
+++ b/addon/stream.js
@@ -2,10 +2,13 @@ import Ember from 'ember';
 
 // As of v1.12, Streams are still private API. Thus, we need to reach in to
 // Ember internals to get access to it.
+// After v2.1, the streams/stream module moved what was `Stream` to a named export and exported
+// a base class as `default`.
 //
 // See https://github.com/emberjs/ember.js/blob/v1.12.0/packages/ember-metal/lib/main.js#L384-L386
 // See https://github.com/emberjs/ember.js/pull/9693
 // See https://github.com/dockyard/ember-cli-i18n/blob/v0.0.6/addon/utils/stream.js
-
-export default Ember.__loader.require('ember-metal/streams/stream')['default'];
+// See https://github.com/emberjs/ember.js/blob/23258c1eadce4f52c814f0441c13880ddf896f31/packages/ember-metal/lib/streams/stream.js
+const streamModule = Ember.__loader.require('ember-metal/streams/stream');
+export default (streamModule.Stream || streamModule['default']);
 export var readHash = Ember.__loader.require('ember-metal/streams/utils').readHash;


### PR DESCRIPTION
Before Ember 2.1, we got the Stream function as the default export of `ember-metal/streams/stream`. After v2.1, the default export changed to a `BasicStream` class and the module exports a named `Stream` subclass.

Thanks, @rwjblue, for making this such an easy fix :)