### PR TITLE
remove Stream awareness from service:i18n

### DIFF
--- a/addon/services/i18n.js
+++ b/addon/services/i18n.js
@@ -1,10 +1,9 @@
 import Ember from "ember";
-import Stream from "../stream";
 import Locale from "../utils/locale";
 import addTranslations from "../utils/add-translations";
 import getLocales from "../utils/get-locales";
 
-const { assert, computed, get, Evented, makeArray, observer, on, typeOf, warn } = Ember;
+const { assert, computed, get, Evented, makeArray, on, typeOf, warn } = Ember;
 const Parent = Ember.Service || Ember.Object;
 
 // @public
@@ -83,17 +82,6 @@ export default Parent.extend(Evented, {
   _locale: computed('locale', function() {
     const locale = this.get('locale');
     return locale ? new Locale(this.get('locale'), this.container) : null;
-  }),
-
-  _buildLocaleStream: on('init', function() {
-    this.localeStream = new Stream(() => {
-      return this.get('locale');
-    });
-  }),
-
-  _notifyLocaleStream: observer('locale', function() {
-    this.localeStream.value(); // force the stream to be dirty
-    this.localeStream.notify();
   })
 
 });

--- a/addon/stream.js
+++ b/addon/stream.js
@@ -2,13 +2,10 @@ import Ember from 'ember';
 
 // As of v1.12, Streams are still private API. Thus, we need to reach in to
 // Ember internals to get access to it.
-// After v2.1, the streams/stream module moved what was `Stream` to a named export and exported
-// a base class as `default`.
 //
 // See https://github.com/emberjs/ember.js/blob/v1.12.0/packages/ember-metal/lib/main.js#L384-L386
 // See https://github.com/emberjs/ember.js/pull/9693
 // See https://github.com/dockyard/ember-cli-i18n/blob/v0.0.6/addon/utils/stream.js
-// See https://github.com/emberjs/ember.js/blob/23258c1eadce4f52c814f0441c13880ddf896f31/packages/ember-metal/lib/streams/stream.js
-const streamModule = Ember.__loader.require('ember-metal/streams/stream');
-export default (streamModule.Stream || streamModule['default']);
-export var readHash = Ember.__loader.require('ember-metal/streams/utils').readHash;
+
+export default Ember.__loader.require('ember-metal/streams/stream')['default'];
+export const readHash = Ember.__loader.require('ember-metal/streams/utils').readHash;

--- a/app/instance-initializers/ember-i18n.js
+++ b/app/instance-initializers/ember-i18n.js
@@ -1,12 +1,24 @@
 import Ember from "ember";
+import Stream from 'ember-i18n/stream';
 import legacyHelper from "ember-i18n/legacy-helper";
 import ENV from '../config/environment';
 
 export default {
   name: 'ember-i18n',
 
-  initialize: function(instance) {
+  initialize(appOrAppInstance) {
     if (legacyHelper != null) {
+      const i18n = appOrAppInstance.container.lookup('service:i18n');
+
+      i18n.localeStream = new Stream(function() {
+        return i18n.get('locale');
+      });
+
+      Ember.addObserver(i18n, 'locale', i18n, function() {
+        this.localeStream.value(); // force the stream to be dirty
+        this.localeStream.notify();
+      });
+
       Ember.HTMLBars._registerHelper('t', legacyHelper);
     }
   }


### PR DESCRIPTION
The only time that the `service:i18n` needs to expose a `localeStream` is when we're using the legacy helper (Ember 1.12). Therefore, instead of always having the service build that Stream, we use the initializer to set it up only when we're installing the legacy helper. This makes the library completely streamless on Ember 1.13+.