### PR TITLE
Calling missingMessage with the I18n service as the context

### DIFF
--- a/addon/utils/locale.js
+++ b/addon/utils/locale.js
@@ -29,7 +29,7 @@ export default class Locale {
       if (this.pluralForm === undefined) { this.pluralForm = config.pluralForm; }
     });
 
-    const defaultConfig = this.container.lookup('ember-i18n@config:zh');
+    const defaultConfig = this.container.lookupFactory('ember-i18n@config:zh');
 
     if (this.rtl === undefined) {
       Ember.warn(`ember-i18n: No RTL configuration found for ${this.id}.`);
@@ -87,7 +87,7 @@ export default class Locale {
   }
 
   _defineMissingTranslationTemplate(key) {
-    const I18n = this.container.lookupFactory('service:i18n');
+    const I18n = this.container.lookup('service:i18n');
     const missingMessage = this.container.lookupFactory('util:i18n/missing-message');
     const locale = this.id;
 

--- a/addon/utils/locale.js
+++ b/addon/utils/locale.js
@@ -29,7 +29,7 @@ export default class Locale {
       if (this.pluralForm === undefined) { this.pluralForm = config.pluralForm; }
     });
 
-    const defaultConfig = this.container.lookupFactory('ember-i18n@config:zh');
+    const defaultConfig = this.container.lookup('ember-i18n@config:zh');
 
     if (this.rtl === undefined) {
       Ember.warn(`ember-i18n: No RTL configuration found for ${this.id}.`);

--- a/addon/utils/locale.js
+++ b/addon/utils/locale.js
@@ -87,10 +87,11 @@ export default class Locale {
   }
 
   _defineMissingTranslationTemplate(key) {
+    const I18n = this.container.lookupFactory('service:i18n');
     const missingMessage = this.container.lookupFactory('util:i18n/missing-message');
     const locale = this.id;
 
-    function missingTranslation(data) { return missingMessage(locale, key, data); }
+    function missingTranslation(data) { return missingMessage.call(I18n, locale, key, data); }
 
     missingTranslation._isMissing = true;
     this.translations[key] = missingTranslation;


### PR DESCRIPTION
Calling missingMessage with the I18n service as the context to make it possible to use I18n to implement a default translation language, for example. see: https://github.com/jamesarosen/ember-i18n/issues/322