### PR TITLE
Use public API for container / registry functions.

### DIFF
--- a/addon/services/i18n.js
+++ b/addon/services/i18n.js
@@ -1,4 +1,5 @@
 import Ember from "ember";
+import getOwner from 'ember-getowner-polyfill';
 import Locale from "../utils/locale";
 import addTranslations from "../utils/add-translations";
 import getLocales from "../utils/get-locales";
@@ -50,7 +51,7 @@ export default Parent.extend(Evented, {
 
   // @public
   addTranslations: function(locale, translations) {
-    addTranslations(locale, translations, this.container);
+    addTranslations(locale, translations, getOwner(this));
     this._addLocale(locale);
 
     if (this.get('locale').indexOf(locale) === 0) {
@@ -60,7 +61,7 @@ export default Parent.extend(Evented, {
 
   // @private
   _initDefaults: on('init', function() {
-    const ENV = this.container.lookupFactory('config:environment');
+    const ENV = getOwner(this)._lookupFactory('config:environment');
 
     if (this.get('locale') == null) {
       var defaultLocale = (ENV.i18n || {}).defaultLocale;
@@ -81,7 +82,7 @@ export default Parent.extend(Evented, {
 
   _locale: computed('locale', function() {
     const locale = this.get('locale');
-    return locale ? new Locale(this.get('locale'), this.container) : null;
+    return locale ? new Locale(this.get('locale'), getOwner(this)) : null;
   })
 
 });

--- a/addon/utils/add-translations.js
+++ b/addon/utils/add-translations.js
@@ -1,15 +1,12 @@
 import Ember from "ember";
 
-export default function addTranslations(locale, newTranslations, container) {
+export default function addTranslations(locale, newTranslations, owner) {
   const key = `locale:${locale}/translations`;
-  var existingTranslations = container.lookupFactory(key);
+  var existingTranslations = owner._lookupFactory(key);
 
   if (existingTranslations == null) {
     existingTranslations = {};
-    // CRUFT: there's no public API for registering factories at runtime.
-    // See http://discuss.emberjs.com/t/whats-the-correct-way-to-register-new-factories-at-runtime/8018
-    const registry = container.registry || container._registry;
-    registry.register(key, existingTranslations);
+    owner.register(key, existingTranslations);
   }
 
   Ember.merge(existingTranslations, newTranslations);

--- a/app/instance-initializers/ember-i18n.js
+++ b/app/instance-initializers/ember-i18n.js
@@ -8,6 +8,7 @@ export default {
 
   initialize(appOrAppInstance) {
     if (legacyHelper != null) {
+      // Used for Ember < 1.13
       const i18n = appOrAppInstance.container.lookup('service:i18n');
 
       i18n.localeStream = new Stream(function() {

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.6",
+    "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "jquery": ">=1.11.1 <3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
-    "ember-cli": "^1.13.8",
+    "ember-cli": "1.13.8",
     "ember-cli-app-version": "^0.5.0",
     "ember-cli-content-security-policy": "^0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "ember-getowner-polyfill": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
As of Ember 2.3, using `this.container` from within an instance that is looked up from the container will issue a deprecation warning suggesting that you should refactor away from the private `this.container` usage to the new public API for using container/registry features (`Ember.getOwner(this)`).

This change pulls in the `ember-getowner-polyfill` to allow us to use `getOwner` on all Ember versions (tested back to 1.10 in that addon's CI).