### PR TITLE
Update ember-try configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   - EMBER_TRY_SCENARIO=default POD_MODULE_PREFIX="dummy/pods"
   - EMBER_TRY_SCENARIO=ember-1-12
   - EMBER_TRY_SCENARIO=ember-1-13
+  - EMBER_TRY_SCENARIO=ember-2-0
+  - EMBER_TRY_SCENARIO=ember-2-1
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,25 +7,31 @@ module.exports = {
     {
       name: 'ember-1-12',
       dependencies: {
-        'ember': 'components/ember#1.12.1'
-      },
-      resolutions: {
-        'ember': 'release'
+        'ember': '~1.12.1'
       }
     },
     {
       name: 'ember-1-13',
       dependencies: {
-        'ember': 'components/ember#1.13.8'
-      },
-      resolutions: {
-        'ember': 'release'
+        'ember': '~1.13.8'
+      }
+    },
+    {
+      name: 'ember-2-0',
+      dependencies: {
+        'ember': '~2.0.0'
+      }
+    },
+    {
+      name: 'ember-2-1',
+      dependencies: {
+        'ember': '~2.1.0'
       }
     },
     {
       name: 'ember-release',
       dependencies: {
-        'ember': 'components/ember#release'
+        'ember': 'release'
       },
       resolutions: {
         'ember': 'release'
@@ -34,7 +40,7 @@ module.exports = {
     {
       name: 'ember-beta',
       dependencies: {
-        'ember': 'components/ember#beta'
+        'ember': 'beta'
       },
       resolutions: {
         'ember': 'beta'
@@ -43,7 +49,7 @@ module.exports = {
     {
       name: 'ember-canary',
       dependencies: {
-        'ember': 'components/ember#canary'
+        'ember': 'canary'
       },
       resolutions: {
         'ember': 'canary'


### PR DESCRIPTION
* Add Ember 2.0.0 to CI (not currently being tested because release is 2.1).
* Add Ember 2.1.0 to CI explicitly (when Ember 2.2.0 ships this week 2.1 will no longer be tested by CI without this change).
* Update resolutions for earlier versions (can't use `release` as a resolution for 1.12 etc).