### PR TITLE
Add TravisCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Ember-I18n - Internationalization for Ember
 
+[![Build Status](https://travis-ci.org/jamesarosen/ember-i18n.svg?branch=master)](https://travis-ci.org/jamesarosen/ember-i18n)
+
 Documentation is in the [wiki](https://github.com/jamesarosen/ember-i18n/wiki). Recommended reading:
 
  * [Installation](https://github.com/jamesarosen/ember-i18n/wiki/Doc:-Installation)


### PR DESCRIPTION
This PR adds a TravisCI build status badge to the README file.

Currently the addon has only 9 of 10 points on Ember Observer because it's not visible that the project is using any sort of CI. @kategengler suggested to add the badge to make the review easier for her.