### PR TITLE
Fix deprecation warning Ember.merge > Ember.assign for ember@2.5.0

### DIFF
--- a/addon/utils/add-translations.js
+++ b/addon/utils/add-translations.js
@@ -1,5 +1,7 @@
 import Ember from "ember";
 
+const assign = Ember.assign || Ember.merge;
+
 export default function addTranslations(locale, newTranslations, owner) {
   const key = `locale:${locale}/translations`;
   var existingTranslations = owner._lookupFactory(key);
@@ -9,5 +11,5 @@ export default function addTranslations(locale, newTranslations, owner) {
     owner.register(key, existingTranslations);
   }
 
-  Ember.merge(existingTranslations, newTranslations);
+  assign(existingTranslations, newTranslations);
 }

--- a/addon/utils/locale.js
+++ b/addon/utils/locale.js
@@ -1,5 +1,6 @@
 import Ember from "ember";
-const { assert, merge, typeOf, warn } = Ember;
+const { assert, typeOf, warn } = Ember;
+const assign = Ember.assign || Ember.merge;
 
 // @private
 //
@@ -111,11 +112,11 @@ function getFlattenedTranslations(id, owner) {
 
   const parentId = parentLocale(id);
   if (parentId) {
-    merge(result, getFlattenedTranslations(parentId, owner));
+    assign(result, getFlattenedTranslations(parentId, owner));
   }
 
   const translations = owner._lookupFactory(`locale:${id}/translations`) || {};
-  merge(result, withFlattenedKeys(translations));
+  assign(result, withFlattenedKeys(translations));
 
   return result;
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -3,11 +3,13 @@ import Application from '../../app';
 import config from '../../config/environment';
 import './ember-i18n/test-helpers';
 
+const assign = Ember.assign || Ember.merge;
+
 export default function startApp(attrs) {
   var application;
 
-  var attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  var attributes = assign({}, config.APP);
+  attributes = assign(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(function() {
     application = Application.create(attributes);


### PR DESCRIPTION
Hi, this is a fix for the deprecation of Ember.merge:
DEPRECATION: Usage of `Ember.merge` is deprecated, use `Ember.assign` instead. [deprecation id: ember-metal.merge]

More info: https://github.com/emberjs/ember.js/pull/12303