### PR TITLE
Replaced usage of `new Ember.Handlebars.SafeString` with `Ember.String.htmlSafe`

### DIFF
--- a/addon/utils/i18n/compile-template.js
+++ b/addon/utils/i18n/compile-template.js
@@ -1,6 +1,6 @@
 import Ember from "ember";
 
-const SafeString = Ember.Handlebars.SafeString;
+const htmlSafe = Ember.String.htmlSafe;
 const get = Ember.get;
 const escapeExpression = Ember.Handlebars.Utils.escapeExpression;
 const tripleStache = /\{\{\{\s*(.*?)\s*\}\}\}/g;
@@ -21,6 +21,6 @@ export default function compileTemplate(template, rtl = false) {
 
     const wrapped = rtl ? `\u202B${result}\u202C` : result;
 
-    return new SafeString(wrapped);
+    return htmlSafe(wrapped);
   };
 }


### PR DESCRIPTION
Using `SafeString` in this way has been deprecated. See: http://emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring

`Ember.String.htmlSafe` has been around since Ember 1.0.0 so I don't see any concerns about backwards compatibility. 