### PR TITLE
Add `isLocalizationFramework` flag.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,7 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-i18n'
+  name: 'ember-i18n',
+
+  isLocalizationFramework: true
 };


### PR DESCRIPTION
This flag can be found/identified by other addons to provide a better experience.  

For example, ember-cli-template-lint would like to provide a warning when templates use "bare strings" (non-translated strings) for projects that are using a localization framework.

When a localization framework is present, and the `bare-strings` rule is not listed in the `.template-lintrc.js` file, a warning will be issued saying:

```
The `bare-strings` rule must be configured when using a localization framework (`ember-i18n`). To prevent this warning, add the following to your `.template-lintrc.js`:

  rules: {
    'bare-strings\': true
  }
```

When `ember install ember-cli-template-lint` is ran for the first time in a project that is already using a localization framework, the proper `.template-lintrc.js` file will be generated (so no additional user interaction is needed).

This was implemented in ember-cli-template-lint in https://github.com/rwjblue/ember-cli-template-lint/pull/94 and released in https://github.com/rwjblue/ember-cli-template-lint/releases/tag/v0.4.4.