### PR TITLE
Import Stream from `ember-htmlbars/streams/stream` on Ember canary

### DIFF
--- a/addon/stream.js
+++ b/addon/stream.js
@@ -6,6 +6,11 @@ import Ember from 'ember';
 // See https://github.com/emberjs/ember.js/blob/v1.12.0/packages/ember-metal/lib/main.js#L384-L386
 // See https://github.com/emberjs/ember.js/pull/9693
 // See https://github.com/dockyard/ember-cli-i18n/blob/v0.0.6/addon/utils/stream.js
+//
+// As of v2.7, Streams are moved to `ember-htmlbars`, we need to check if `ember-metal/streams/stream` exists
 
-export default Ember.__loader.require('ember-metal/streams/stream')['default'];
-export const readHash = Ember.__loader.require('ember-metal/streams/utils').readHash;
+const _registry = Ember.__loader.registry;
+const _require = Ember.__loader.require;
+
+export default _registry['ember-metal/streams/stream'] ? _require('ember-metal/streams/stream')['default'] : _require('ember-htmlbars/streams/stream')['default'];
+export const readHash = _registry['ember-metal/streams/utils'] ? _require('ember-metal/streams/utils').readHash :  _require('ember-htmlbars/streams/utils').readHash;


### PR DESCRIPTION
As of v2.7, Streams are moved to `ember-htmlbars`, we need to check if `ember-metal/streams/stream` exists.