### PR TITLE
default translations and access to Locale

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## 4.2.2
+
+ * set `isLocalizationFramework` for other addons
+ * change `Stream` import to support latest Ember (even though
+   ember-i18n doesn't _rely_ on `Stream` for Ember 1.13+, it needs
+   to _import_ it)
+
 ## 4.2.1
 
  * use `Ember.assign` instead of `Ember.merge` if available

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,5 +1,6 @@
 import compileTemplate from "./utils/i18n/compile-template";
 import Service from "./services/i18n";
 import translationMacro from "./utils/macro";
+import Locale from "./utils/locale";
 
-export { compileTemplate, Service, translationMacro };
+export { compileTemplate, Service, translationMacro, Locale };

--- a/addon/services/i18n.js
+++ b/addon/services/i18n.js
@@ -9,7 +9,6 @@ const Parent = Ember.Service || Ember.Object;
 
 // @public
 export default Parent.extend(Evented, {
-
   // @public
   // The user's locale.
   locale: null,
@@ -22,7 +21,15 @@ export default Parent.extend(Evented, {
   //
   // Returns the translation `key` interpolated with `data`
   // in the current `locale`.
-  t: function(key, data = {}) {
+  t(key, data = {}) {
+    Ember.deprecate('locale is a reserved attribute', !data.hasOwnProperty('locale'), {
+      id: 'ember-i18n.reserve-locale'
+    });
+
+    Ember.deprecate('htmlSafe is a reserved attribute', !data.hasOwnProperty('htmlSafe'), {
+      id: 'ember-i18n.reserve-htmlSafe'
+    });
+
     const locale = this.get('_locale');
     assert("I18n: Cannot translate when locale is null", locale);
     const count = get(data, 'count');
@@ -40,7 +47,7 @@ export default Parent.extend(Evented, {
   },
 
   // @public
-  exists: function(key, data = {}) {
+  exists(key, data = {}) {
     const locale = this.get('_locale');
     assert("I18n: Cannot check existance when locale is null", locale);
     const count = get(data, 'count');
@@ -50,7 +57,7 @@ export default Parent.extend(Evented, {
   },
 
   // @public
-  addTranslations: function(locale, translations) {
+  addTranslations(locale, translations) {
     addTranslations(locale, translations, getOwner(this));
     this._addLocale(locale);
 
@@ -66,7 +73,10 @@ export default Parent.extend(Evented, {
     if (this.get('locale') == null) {
       var defaultLocale = (ENV.i18n || {}).defaultLocale;
       if (defaultLocale == null) {
-        warn('ember-i18n did not find a default locale; falling back to "en".', false, { id: 'ember-i18n.default-locale' });
+        warn('ember-i18n did not find a default locale; falling back to "en".', false, {
+          id: 'ember-i18n.default-locale'
+        });
+
         defaultLocale = 'en';
       }
       this.set('locale', defaultLocale);
@@ -82,7 +92,7 @@ export default Parent.extend(Evented, {
 
   _locale: computed('locale', function() {
     const locale = this.get('locale');
+
     return locale ? new Locale(this.get('locale'), getOwner(this)) : null;
   })
-
 });

--- a/addon/stream.js
+++ b/addon/stream.js
@@ -6,6 +6,11 @@ import Ember from 'ember';
 // See https://github.com/emberjs/ember.js/blob/v1.12.0/packages/ember-metal/lib/main.js#L384-L386
 // See https://github.com/emberjs/ember.js/pull/9693
 // See https://github.com/dockyard/ember-cli-i18n/blob/v0.0.6/addon/utils/stream.js
+//
+// As of v2.7, Streams are moved to `ember-htmlbars`, we need to check if `ember-metal/streams/stream` exists
 
-export default Ember.__loader.require('ember-metal/streams/stream')['default'];
-export const readHash = Ember.__loader.require('ember-metal/streams/utils').readHash;
+const _registry = Ember.__loader.registry;
+const _require = Ember.__loader.require;
+
+export default _registry['ember-metal/streams/stream'] ? _require('ember-metal/streams/stream')['default'] : _require('ember-htmlbars/streams/stream')['default'];
+export const readHash = _registry['ember-metal/streams/utils'] ? _require('ember-metal/streams/utils').readHash :  _require('ember-htmlbars/streams/utils').readHash;

--- a/addon/utils/locale.js
+++ b/addon/utils/locale.js
@@ -20,7 +20,7 @@ function Locale(id, owner) {
 
 Locale.prototype = {
   rebuild() {
-    this.translations = getFlattenedTranslations(this.id, this.owner);
+    this.translations = getFlattenedTranslations(this.id, this.owner, true);
     this._setConfig();
   },
 
@@ -107,12 +107,17 @@ Locale.prototype = {
   }
 };
 
-function getFlattenedTranslations(id, owner) {
+function getFlattenedTranslations(id, owner, includeDefault=true) {
   const result = {};
+
+  if (includeDefault) {
+    const translations = owner._lookupFactory(`locale:translations`) || {};
+    assign(result, withFlattenedKeys(translations));
+  }
 
   const parentId = parentLocale(id);
   if (parentId) {
-    assign(result, getFlattenedTranslations(parentId, owner));
+    assign(result, getFlattenedTranslations(parentId, owner, false));
   }
 
   const translations = owner._lookupFactory(`locale:${id}/translations`) || {};

--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,6 @@
     "ember-resolver": "~0.1.18",
     "jquery": ">=1.11.1 <3.0.0",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": ">=1.17.1 <3.0.0"
+    "qunit": ">=1.17.1 <2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-i18n",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Internationalization for Ember",
   "directories": {
     "doc": "doc",

--- a/tests/dummy/app/locales/translations.js
+++ b/tests/dummy/app/locales/translations.js
@@ -1,0 +1,3 @@
+export default {
+  'defined.in.default': 'Defined in default'
+};

--- a/tests/unit/i18n-t-test.js
+++ b/tests/unit/i18n-t-test.js
@@ -91,3 +91,9 @@ test("check unknown locale", function(assert) {
   const result = this.subject({ locale: 'uy' }).t('not.yet.translated', {count: 2});
   assert.equal('Missing translation: not.yet.translated', result);
 });
+
+test('falls back to default translations', function(assert) {
+  assert.equal(this.subject({ locale: 'en' }).t('defined.in.default', {}), 'Defined in default');
+  assert.equal(this.subject({ locale: 'es' }).t('defined.in.default', {}), 'Defined in default');
+  assert.equal(this.subject({ locale: 'en-ps' }).t('defined.in.default', {}), 'Defined in default');
+});


### PR DESCRIPTION
Added 2 features:
- the ability to have a common default translations file located in app/locales/translations.js 
  I use this for product names, and language names that transcend the locale...
  And therefore I don't want to define it in every base language.
- expose Locale so that I can access translations for a certain language from the code. This is useful in the missing-message.js 
