### PR TITLE
exists returns true when checked twice

### DIFF
--- a/addon/services/i18n.js
+++ b/addon/services/i18n.js
@@ -53,7 +53,7 @@ export default Parent.extend(Evented, {
     const count = get(data, 'count');
 
     const translation = locale.findTranslation(makeArray(key), count);
-    return typeOf(translation.result) !== 'undefined';
+    return typeOf(translation.result) !== 'undefined' && !translation.result._isMissing;
   },
 
   // @public

--- a/tests/unit/i18n-exists-test.js
+++ b/tests/unit/i18n-exists-test.js
@@ -33,3 +33,11 @@ test('fallsback to the parent locale', function(assert) {
 
   assert.equal(i18n.exists('no.interpolations.either'), true);
 });
+
+test('non-existing translations when checked twice do not exist', function (assert) {
+  const i18n = this.subject({ locale: 'en' });
+
+  assert.equal(i18n.exists('not.existing'), false);
+  assert.equal(i18n.t('not.existing'), 'Missing translation: not.existing');
+  assert.equal(i18n.exists('not.existing'), false);
+});


### PR DESCRIPTION
Hey!

We've been hitting this issue which causes an infinite loop when trying to do fallback lookups.  :cry: 

Basically, when you hit a missing translation the system defines a translation with the _isMissing flag. Exists needs to check that flag.

Cheers!