### PR TITLE
Use `Ember.String.htmlSafe` instead of `new Ember.Handlebars.SafeString`.

### DIFF
--- a/addon/utils/i18n/compile-template.js
+++ b/addon/utils/i18n/compile-template.js
@@ -1,6 +1,6 @@
 import Ember from "ember";
 
-const SafeString = Ember.Handlebars.SafeString;
+const htmlSafe = Ember.String.htmlSafe;
 const get = Ember.get;
 const escapeExpression = Ember.Handlebars.Utils.escapeExpression;
 const tripleStache = /\{\{\{\s*(.*?)\s*\}\}\}/g;
@@ -21,6 +21,6 @@ export default function compileTemplate(template, rtl = false) {
 
     const wrapped = rtl ? `\u202B${result}\u202C` : result;
 
-    return new SafeString(wrapped);
+    return htmlSafe(wrapped);
   };
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-disable-prototype-extensions": "^1.0.1",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.3",
+    "ember-string-ishtmlsafe-polyfill": "^1.0.0",
     "ember-try": "0.0.8"
   },
   "keywords": [

--- a/tests/unit/utils/i18n/default-compiler-test.js
+++ b/tests/unit/utils/i18n/default-compiler-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
 import { compileTemplate } from 'ember-i18n';
+import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 module('compile-template');
 
@@ -55,7 +56,7 @@ test('it treats triple-stache interpolations as HTML-safe', function(assert) {
 
 test('it returns HTML-safe strings', function(assert) {
   const result = compileAndEval('Roast the hazelnuts');
-  assert.ok(result instanceof Ember.Handlebars.SafeString);
+  assert.ok(isHTMLSafe(result));
 });
 
 // Right-to-Left Support


### PR DESCRIPTION
Using `Ember.Handlebars.SafeString` is deprecated in Ember 2.8. See: http://emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring

A few notes. `Ember.String.htmlSafe` has existed since pre-1.0.0 so there should no concern of backwards compat. Second, the polyfill for `Ember.String.isHtmlSafe` is only used by the tests so it only needs to be a `devDependency`.