### PR TITLE
Added an `until` property when calling `Ember.deprecate`

### DIFF
--- a/addon/services/i18n.js
+++ b/addon/services/i18n.js
@@ -23,11 +23,13 @@ export default Parent.extend(Evented, {
   // in the current `locale`.
   t(key, data = {}) {
     Ember.deprecate('locale is a reserved attribute', !data.hasOwnProperty('locale'), {
-      id: 'ember-i18n.reserve-locale'
+      id: 'ember-i18n.reserve-locale',
+      until: '5.0.0'
     });
 
     Ember.deprecate('htmlSafe is a reserved attribute', !data.hasOwnProperty('htmlSafe'), {
-      id: 'ember-i18n.reserve-htmlSafe'
+      id: 'ember-i18n.reserve-htmlSafe',
+      until: '5.0.0'
     });
 
     const locale = this.get('_locale');


### PR DESCRIPTION
This resolves deprecation warnings seen with Ember >= 2.2 and ~~ember-i18n >= 4.2.2~~ ember-i18n > 4.2.2. 

This deprecate was originally added via #381. In that PR it was stated the deprecation was targeted at 5.x. So I made the `until` value reflect that (see diff). 