### PR TITLE
Fixing new issue with Ember 2.9

### DIFF
--- a/addon/services/i18n.js
+++ b/addon/services/i18n.js
@@ -22,12 +22,12 @@ export default Parent.extend(Evented, {
   // Returns the translation `key` interpolated with `data`
   // in the current `locale`.
   t(key, data = {}) {
-    Ember.deprecate('locale is a reserved attribute', !data.hasOwnProperty('locale'), {
+    Ember.deprecate('locale is a reserved attribute', data['locale'] === undefined, {
       id: 'ember-i18n.reserve-locale',
       until: '5.0.0'
     });
 
-    Ember.deprecate('htmlSafe is a reserved attribute', !data.hasOwnProperty('htmlSafe'), {
+    Ember.deprecate('htmlSafe is a reserved attribute', data['htmlSafe'] === undefined, {
       id: 'ember-i18n.reserve-htmlSafe',
       until: '5.0.0'
     });


### PR DESCRIPTION
With Glimmer2, Ember.Helpers will receive their `namedArgs` as an EmptyObject. This created a problem using `hasOwnProperty` in the service. This is a simple work around.

See: https://github.com/emberjs/ember.js/issues/14161