### PR TITLE
GH-403: Add no-op ember-i18n initializer

### DIFF
--- a/addon/initializers/ember-i18n.js
+++ b/addon/initializers/ember-i18n.js
@@ -1,3 +1,7 @@
+// As of 4.3.0 using the ember-i18n initializer is no longer necessary.
+//
+// This is a no-op initializer to prevent applications that relied on the
+// 'ember-i18n' initializer in their own workflow from breaking.
 export default {
   name: 'ember-i18n',
   initialize() {

--- a/addon/initializers/ember-i18n.js
+++ b/addon/initializers/ember-i18n.js
@@ -1,0 +1,9 @@
+import Ember from "ember";
+
+export default {
+  name: 'ember-i18n',
+
+  initialize(registry) {
+    // No-op.
+  }
+};

--- a/addon/initializers/ember-i18n.js
+++ b/addon/initializers/ember-i18n.js
@@ -1,9 +1,6 @@
-import Ember from "ember";
-
 export default {
   name: 'ember-i18n',
-
-  initialize(registry) {
+  initialize() {
     // No-op.
   }
 };

--- a/addon/instance-initializers/ember-i18n.js
+++ b/addon/instance-initializers/ember-i18n.js
@@ -1,0 +1,11 @@
+// As of 4.3.0 using the ember-i18n instance initializer is no longer
+// necessary.
+//
+// This is a no-op initializer to prevent applications that relied on the
+// 'ember-i18n' instance initializer in their own workflow from breaking.
+export default {
+  name: 'ember-i18n',
+  initialize() {
+    // No-op.
+  }
+};

--- a/app/initializers/ember-i18n.js
+++ b/app/initializers/ember-i18n.js
@@ -1,0 +1,2 @@
+import initializer from 'ember-i18n/initializers/ember-i18n';
+export default initializer;

--- a/app/instance-initializers/ember-i18n.js
+++ b/app/instance-initializers/ember-i18n.js
@@ -1,0 +1,2 @@
+import initializer from 'ember-i18n/instance-initializers/ember-i18n';
+export default initializer;


### PR DESCRIPTION
The removal of the ember-i18n initializer had unseen consequences for
applications that were injecting the i18n service into other areas of
the application, as recommended by documentation in the project's wiki
(https://github.com/jamesarosen/ember-i18n/wiki/Doc:-i18n-Service).

As per the discussion in GH-31 this adds a no-op initializer back into
the code base to prevent breaks for applications injecting the i18n
service as per the wiki.