### PR TITLE
Do not observe computed properties that are not consumed

### DIFF
--- a/addon/helper.js
+++ b/addon/helper.js
@@ -3,15 +3,13 @@ import Ember from "ember";
 export default Ember.Helper.extend({
   i18n: Ember.inject.service(),
 
-  _locale: Ember.computed.readOnly('i18n.locale'),
-
   compute: function(params, interpolations) {
     const key = params[0];
     const i18n = this.get('i18n');
     return i18n.t(key, interpolations);
   },
 
-  _recomputeOnLocaleChange: Ember.observer('_locale', function() {
+  _recomputeOnLocaleChange: Ember.observer('i18n.locale', function() {
     this.recompute();
   })
 });


### PR DESCRIPTION
- Ember docs state that computed properties that are not consumed will not trigger observers, unfortunately this is not true for readOnly properties due to a current bug in ember emberjs/ember.js#9265
- Update the i18n helper to not observe a readOnly computed property for when this issue is eventually fixed