### PR TITLE
Updated the usage of `ember-getowner-polyfill` to fix deprecation

### DIFF
--- a/addon/services/i18n.js
+++ b/addon/services/i18n.js
@@ -1,10 +1,9 @@
 import Ember from "ember";
-import getOwner from 'ember-getowner-polyfill';
 import Locale from "../utils/locale";
 import addTranslations from "../utils/add-translations";
 import getLocales from "../utils/get-locales";
 
-const { assert, computed, get, Evented, makeArray, on, typeOf, warn } = Ember;
+const { assert, computed, get, Evented, makeArray, on, typeOf, warn, getOwner } = Ember;
 const Parent = Ember.Service || Ember.Object;
 
 // @public

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "broccoli-funnel": "^1.0.6",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-version-checker": "^1.1.6",
-    "ember-getowner-polyfill": "^1.0.0"
+    "ember-getowner-polyfill": "^1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
An update to the `ember-getowner-polyfill` caused deprecations to be spewed in my builds. Fixing that. See: https://github.com/rwjblue/ember-getowner-polyfill/issues/5 .