### PR TITLE
Use VersionChecker's forEmber to support ember-source

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     this._super.init && this._super.init.apply(this, arguments);
 
     var checker = new VersionChecker(this);
-    var dep = checker.for('ember', 'bower');
+    var dep = checker.forEmber();
     this.hasEmberHelper = !dep.lt('1.13.0');
   },
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "broccoli-funnel": "^1.0.6",
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-version-checker": "^1.1.6",
+    "ember-cli-version-checker": "^1.2.0",
     "ember-getowner-polyfill": "^1.1.0"
   },
   "ember-addon": {


### PR DESCRIPTION
This PR updates ember-cli-version-checker to support newer ember versions that use ember-source.