### PR TITLE
Update ember-string-ishtmlsafe-polyfill.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
-    "ember-string-ishtmlsafe-polyfill": "^1.0.1",
+    "ember-string-ishtmlsafe-polyfill": "^1.1.0",
     "ember-source": "^2.11.0",
     "ember-welcome-page": "^2.0.2",
     "loader.js": "^4.0.10"

--- a/tests/unit/utils/i18n/default-compiler-test.js
+++ b/tests/unit/utils/i18n/default-compiler-test.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
 import { compileTemplate } from 'ember-i18n';
-import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
+
+const { htmlSafe, isHTMLSafe } = Ember.String;
 
 module('compile-template');
 
@@ -42,7 +43,7 @@ test('it treats interpolations as HTML-unsafe', function(assert) {
 
 test('it obeys interpolations marked as HTML-safe', function(assert) {
   const result = compileAndEval('Heat oil over {{temp}} heat.', {
-    temp: Ember.String.htmlSafe('<strong>medium</strong>')
+    temp: htmlSafe('<strong>medium</strong>')
   });
   assert.equal(result, 'Heat oil over <strong>medium</strong> heat.');
 });


### PR DESCRIPTION
👋 -- We're updating [ember-string-ishtmlsafe-polyfill](https://github.com/workmanw/ember-string-ishtmlsafe-polyfill) to be a "native polyfill". Following the pattern provided by [ember-assign-polyfill](https://github.com/shipshapecode/ember-assign-polyfill) and [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill).