### PR TITLE
fixes getLocales returning duplicates

### DIFF
--- a/addon/utils/get-locales.js
+++ b/addon/utils/get-locales.js
@@ -11,5 +11,6 @@ export default function getLocales() {
       }
       return locales;
     }, Ember.A())
+    .uniq()
     .sort();
 }


### PR DESCRIPTION
`getLocales()` is returning duplicates in case you have addons with translations in your app. Then you end-up having duplicates in the `i18n.locales` service's property, and since it's the property used in the example to create the language switch, you endup with many times the same language in that switch.