### PR TITLE
Add support for automatically choosing different i18n keys for different countries

### DIFF
--- a/addon/services/i18n.js
+++ b/addon/services/i18n.js
@@ -13,6 +13,17 @@ export default Parent.extend(Evented, {
   locale: null,
 
   // @public
+  countryCode: Ember.computed({
+    set(key, value) {
+      if(Ember.isBlank(value) || value.length !== 2 || value !== value.toUpperCase()) {
+        throw new Error('Invalid countryCode, expected a two-character uppercase string e.g. "US"');
+      }
+      this.set('_countryCode', value);
+      return value;
+    }
+  }),
+
+  // @public
   // A list of found locales.
   locales: computed(getLocales),
 
@@ -36,8 +47,14 @@ export default Parent.extend(Evented, {
     const count = get(data, 'count');
 
     const defaults = makeArray(get(data, 'default'));
+    const countryCode = this.get('_countryCode');
 
-    defaults.unshift(key);
+    if (defaults.length === 0 && Ember.isPresent(countryCode)) {
+      defaults.push(`${key}.${countryCode}`, `${key}.default`, key);
+    } else {
+      defaults.unshift(key);
+    }
+
     const template = locale.getCompiledTemplate(defaults, count);
 
     if (template._isMissing) {

--- a/tests/dummy/app/locales/en/translations.js
+++ b/tests/dummy/app/locales/en/translations.js
@@ -9,5 +9,8 @@ export default {
   'pluralized.translation': {
     one: 'One Click',
     other: '{{count}} Clicks'
-  }
+  },
+
+  'default1.US': 'default1.US',
+  'default2.default': 'default2.default'
 };

--- a/tests/unit/i18n-t-test.js
+++ b/tests/unit/i18n-t-test.js
@@ -120,3 +120,11 @@ test("check unknown locale", function(assert) {
   const result = this.subject({ locale: 'uy' }).t('not.yet.translated', {count: 2});
   assert.equal('Missing translation: not.yet.translated', result);
 });
+
+test("applies countryCode defaults", function(assert) {
+  const i18n = this.subject({ locale: 'en' });
+  run(i18n, 'set', 'countryCode', 'US');
+
+  assert.equal('' + i18n.t('default1'), 'default1.US');
+  assert.equal('' + i18n.t('default2'), 'default2.default');
+});


### PR DESCRIPTION
Example: if countryCode is set to RU then lookup keys in order: <key>.RU, <key>.default, <key>