### PR TITLE
use textContent instead of innerHTML

### DIFF
--- a/addon-test-support/-private/assert-translation.js
+++ b/addon-test-support/-private/assert-translation.js
@@ -3,7 +3,7 @@
 export default (function() {
   if (typeof QUnit !== 'undefined' && typeof QUnit.assert.ok === 'function') {
     return function(element, key, text) {
-      QUnit.assert.ok(document.querySelector(element).innerHTML.indexOf(text) !== -1, `Found translation key ${key} in ${element}`);
+      QUnit.assert.ok(document.querySelector(element).textContent.indexOf(text) !== -1, `Found translation key ${key} in ${element}`);
     };
   } else if (typeof expect === 'function') {
     return function(element, key, text) {


### PR DESCRIPTION
@jamesarosen I think I made a mistake in the original PR.  Maybe `textContent` would be better.  Plus stuff like `&` and such would be parsed differently.