### PR TITLE
FEATURE: add default locale fallback

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+## 5.2.0
+ * Added support for default locale fallback with a new configuration named `defaultFallback`
 ## 5.1.0
  * Expose test helpers in `addon-test-support/`, which is now standard for Ember addons
 ## 5.0.2

--- a/addon/utils/locale.js
+++ b/addon/utils/locale.js
@@ -121,6 +121,16 @@ function getFlattenedTranslations(id, owner) {
     assign(result, getFlattenedTranslations(parentId, owner));
   }
 
+  let envConfig = owner.factoryFor('config:environment').class;
+  let ENV = (envConfig.i18n || {});
+  let defaultLocale = ENV.defaultLocale;
+  let defaultFallback = ENV.defaultFallback;
+  if (defaultFallback && defaultLocale && defaultLocale !== id) {
+    let defaultFactory = owner.factoryFor(`locale:${defaultLocale}/translations`);
+    let defaultTranslations = defaultFactory && defaultFactory.class;
+    assign(result, withFlattenedKeys(defaultTranslations || {}));
+  }
+
   let factory = owner.factoryFor(`locale:${id}/translations`);
   let translations = factory && factory.class;
   assign(result, withFlattenedKeys(translations || {}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-i18n",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-i18n",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Internationalization for Ember",
   "directories": {
     "doc": "doc",

--- a/tests/dummy/app/locales/en/translations.js
+++ b/tests/dummy/app/locales/en/translations.js
@@ -1,4 +1,7 @@
 export default {
+  'defined.in.default': {
+    value: 'Default {{count}} value'
+  },
   'no.interpolations': 'text with no interpolations',
   'no.interpolations.either': 'another text without interpolations',
 

--- a/tests/unit/i18n-t-test.js
+++ b/tests/unit/i18n-t-test.js
@@ -120,3 +120,80 @@ test("check unknown locale", function(assert) {
   const result = this.subject({ locale: 'uy' }).t('not.yet.translated', {count: 2});
   assert.equal('Missing translation: not.yet.translated', result);
 });
+
+test('provided default translation works as expected when locale is default', function(assert) {
+  this.register('config:environment', {
+    i18n: {
+      defaultLocale: 'en',
+      defaultFallback: true
+    }
+  });
+  const i18n = this.subject({ locale: 'en' });
+  assert.equal('' + i18n.t('defined.in.default.value', { count: 2 }), 'Default 2 value');
+});
+
+test('falls back to default translation when label not found for locale', function(assert) {
+  this.register('config:environment', {
+    i18n: {
+      defaultLocale: 'en',
+      defaultFallback: true
+    }
+  });
+  const i18n = this.subject({ locale: 'es' });
+  assert.equal('' + i18n.t('defined.in.default.value', { count: 2 }), 'Default 2 value');
+});
+
+test('falls back to default translation when label not found and locale not found', function(assert) {
+  this.register('config:environment', {
+    i18n: {
+      defaultLocale: 'en',
+      defaultFallback: true
+    }
+  });
+  const i18n = this.subject({ locale: 'foobz' });
+  assert.equal('' + i18n.t('defined.in.default.value', { count: 2 }), 'Default 2 value');
+});
+
+test('does not fall back to default translation when configuration true but defaultLocale falsy', function(assert) {
+  this.register('config:environment', {
+    i18n: {
+      defaultLocale: '',
+      defaultFallback: true
+    }
+  });
+  const i18n = this.subject({ locale: 'es' });
+  assert.equal('' + i18n.t('defined.in.default.value', { count: 2 }), 'Missing translation: defined.in.default.value');
+});
+
+test('does not fall back to default translation when configuration false', function(assert) {
+  this.register('config:environment', {
+    i18n: {
+      defaultLocale: 'en',
+      defaultFallback: false
+    }
+  });
+  const i18n = this.subject({ locale: 'es' });
+  assert.equal('' + i18n.t('defined.in.default.value', { count: 2 }), 'Missing translation: defined.in.default.value');
+});
+
+test('does not fall back to default translation when configuration null', function(assert) {
+  this.register('config:environment', {
+    i18n: {
+      defaultLocale: 'en',
+      defaultFallback: null
+    }
+  });
+  const i18n = this.subject({ locale: 'es' });
+  assert.equal('' + i18n.t('defined.in.default.value', { count: 2 }), 'Missing translation: defined.in.default.value');
+});
+
+test('does not fall back to default translation when configuration undefined', function(assert) {
+  this.register('config:environment', {
+    i18n: {
+      defaultLocale: 'en',
+      defaultFallback: undefined
+    }
+  });
+  const i18n = this.subject({ locale: 'es' });
+  assert.equal('' + i18n.t('defined.in.default.value', { count: 2 }), 'Missing translation: defined.in.default.value');
+});


### PR DESCRIPTION
To support a default locale fallback I've added a configuration named `defaultFallback` that when configured as `true` allows i18n to provide translations that might be absent from the configured/active locale. This fallback locale is taken directly from the current i18n configuration named `defaultLocale` (as this would make the most sense and avoids yet another config option).

PR covers the basics but I'm open to feedback! Thanks again for providing this great OSS addon!

cc @jamesarosen @snewcomer 