### PR TITLE
Use console-ui for deprecation message

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
     var checker = new VersionChecker(this);
     var dep = checker.forEmber();
     this.hasEmberHelper = !dep.lt('1.13.0');
-    console.log('ember-i18n has been deprecated in favor of ember-intl'); // eslint-disable-line no-console
+    this.ui.writeDeprecateLine('ember-i18n has been deprecated in favor of ember-intl');
   },
 
   treeFor(name) {


### PR DESCRIPTION
This gives some better formatting (yellow chalk), but also acknowledges the `--silent` flag of Ember CLI.

The latter does give us some serious problems here, as we parse the test output (in xunit format) in CI, and because of the (non-silent) console output, the output of `ember t` is obviously no valid XML anymore, failing our builds.